### PR TITLE
feat: ads.txt の動的生成機能の実装 (#48)

### DIFF
--- a/src/app/api/ads.txt/route.test.ts
+++ b/src/app/api/ads.txt/route.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import db, { initSchema } from '@/lib/db';
+import { GET } from './route';
+
+describe('GET /api/ads.txt', () => {
+  beforeEach(() => {
+    // Clear and initialize DB
+    db.exec('DROP TABLE IF EXISTS publishers');
+    initSchema(db);
+
+    // Insert mock publisher
+    db.prepare("INSERT INTO publishers (id, name, domain) VALUES (1, 'Test Publisher', 'test.com')").run();
+  });
+
+  it('should return 400 if publisher_id is missing', async () => {
+    const req = new NextRequest('http://localhost/api/ads.txt');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe('publisher_id is required');
+  });
+
+  it('should return 404 if publisher is not found', async () => {
+    const req = new NextRequest('http://localhost/api/ads.txt?publisher_id=999');
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe('Publisher not found');
+  });
+
+  it('should return valid ads.txt content for an existing publisher', async () => {
+    const req = new NextRequest('http://localhost/api/ads.txt?publisher_id=1');
+    const res = await GET(req);
+    
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/plain');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600');
+
+    const content = await res.text();
+    expect(content).toContain('# ads.txt for Publisher 1');
+    expect(content).toContain('adnetwork.local, 1, DIRECT, f08c47fec0942fa0');
+  });
+});

--- a/src/app/api/ads.txt/route.ts
+++ b/src/app/api/ads.txt/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import db from "@/lib/db";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const publisherId = searchParams.get("publisher_id");
+
+  if (!publisherId) {
+    return new NextResponse("publisher_id is required", { status: 400 });
+  }
+
+  // Check if the publisher exists
+  const publisher = db.prepare('SELECT id FROM publishers WHERE id = ?').get(publisherId);
+  if (!publisher) {
+    return new NextResponse("Publisher not found", { status: 404 });
+  }
+
+  // Define the ads.txt content
+  // Format: <Field #1>, <Field #2>, <Field #3>, <Field #4>
+  // Field 1: Domain name of the advertising system
+  // Field 2: Publisher's Account ID
+  // Field 3: Type of Account/Relationship (DIRECT or RESELLER)
+  // Field 4: Certification Authority ID (Optional, using a placeholder for now)
+  const adNetworkDomain = process.env.ADNETWORK_DOMAIN || 'adnetwork.local';
+  const certificationId = 'f08c47fec0942fa0'; // Placeholder Certification ID
+  
+  const content = `# ads.txt for Publisher ${publisherId}\n${adNetworkDomain}, ${publisherId}, DIRECT, ${certificationId}\n`;
+
+  return new NextResponse(content, {
+    headers: {
+      "Content-Type": "text/plain",
+      "Cache-Control": "public, max-age=3600" // Cache for 1 hour to reduce DB load
+    },
+  });
+}

--- a/src/app/publisher/[id]/page.tsx
+++ b/src/app/publisher/[id]/page.tsx
@@ -119,6 +119,25 @@ export default async function PublisherDashboard({ params }: PageProps) {
           {/* Integration Section */}
           <div className="flex flex-col gap-8">
             <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-100">
+              <h2 className="text-xl font-bold mb-4 text-gray-800">ads.txt Configuration</h2>
+              <p className="text-sm text-gray-600 mb-4">
+                プラットフォームの透明性を高めるため、以下のリンクからあなたの <code>ads.txt</code> を取得し、あなたのサイトのルートディレクトリに配置してください。
+              </p>
+              <div className="bg-gray-50 p-4 rounded-lg flex items-center justify-between border">
+                <code className="text-sm text-gray-800 truncate">
+                  /api/ads.txt?publisher_id={publisher.id}
+                </code>
+                <a 
+                  href={`/api/ads.txt?publisher_id=${publisher.id}`} 
+                  target="_blank"
+                  className="ml-4 text-sm font-medium text-blue-600 hover:text-blue-800 whitespace-nowrap"
+                >
+                  View ads.txt ↗
+                </a>
+              </div>
+            </section>
+
+            <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-100">
               <h2 className="text-xl font-bold mb-4 text-gray-800">Ad Tag Integration</h2>
               <p className="text-sm text-gray-600 mb-4">下記のタグをあなたのサイト (<code>{publisher.domain}</code>) に埋め込んでください。</p>
               <pre className="bg-gray-900 text-emerald-400 p-4 rounded-lg text-xs overflow-x-auto font-mono">


### PR DESCRIPTION
### 概要
Issue #48 に対応し、パブリッシャーが自身のサイトに設置するための  を動的に生成するエンドポイントを実装しました。

### 変更内容
1. **API エンドポイントの作成 ()**
   - `publisher_id` を受け取り、IABの標準フォーマットに従ってテキストを返すエンドポイントを追加しました。
   - 存在しないパブリッシャーの場合は 404 を返します。
2. **パブリッシャーダッシュボードの更新 ()**
   - パブリッシャーが自身の `ads.txt` の内容を確認・コピーできるように、ダッシュボード上にリンクと説明を追加しました。
3. **テストの追加**
   - `route.test.ts` を作成し、正常系・異常系（400, 404）のレスポンスを検証しています。

### 確認方法
- `npm test` が全てパスすることを確認済み。
- ローカル環境で `http://localhost:3000/api/ads.txt?publisher_id=1` にアクセスし、正しいテキストファイルが返されることを確認できます。
