### PR TITLE
feat: 配信先別レポート (Placement Report) の実装 (#49)

### DIFF
--- a/src/app/advertiser/[id]/page.tsx
+++ b/src/app/advertiser/[id]/page.tsx
@@ -1,11 +1,12 @@
 import db from "@/lib/db";
-import { getDailyStats } from "@/services/stats";
+import { getDailyStats, getPlacementStats } from "@/services/stats";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import StatsChart from "@/components/StatsChart";
 import AdsPerformanceTable from "@/components/AdsPerformanceTable";
 import CampaignsTable from "@/components/CampaignsTable";
 import AdGroupsTable from "@/components/AdGroupsTable";
+import PlacementReportTable from "@/components/PlacementReportTable";
 import { createCampaign, createAdGroup, createAd } from "./actions";
 
 interface PageProps {
@@ -44,6 +45,7 @@ export default async function AdvertiserDashboard({ params }: PageProps) {
   `).all(id) as any[];
 
   const dailyStats = getDailyStats({ advertiserId: id }) as any[];
+  const placementStats = getPlacementStats(id) as any[];
   const totalImps = dailyStats.reduce((acc, curr) => acc + curr.impressions, 0);
   const totalClicks = dailyStats.reduce((acc, curr) => acc + curr.clicks, 0);
 
@@ -84,10 +86,14 @@ export default async function AdvertiserDashboard({ params }: PageProps) {
         </section>
 
         {/* Charts */}
-        <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-100">
-          <h2 className="text-xl font-bold mb-6 text-gray-800 tracking-tight">Performance Over Time</h2>
-          <StatsChart data={dailyStats} />
-        </section>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-100">
+            <h2 className="text-xl font-bold mb-6 text-gray-800 tracking-tight">Performance Over Time</h2>
+            <StatsChart data={dailyStats} />
+          </section>
+          
+          <PlacementReportTable placements={placementStats} />
+        </div>
 
         {/* Action Forms (Create New) */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/src/components/PlacementReportTable.tsx
+++ b/src/components/PlacementReportTable.tsx
@@ -1,0 +1,68 @@
+interface PlacementStat {
+  id: number;
+  name: string;
+  domain: string;
+  impressions: number;
+  clicks: number;
+}
+
+interface PlacementReportTableProps {
+  placements: PlacementStat[];
+}
+
+export default function PlacementReportTable({ placements }: PlacementReportTableProps) {
+  return (
+    <section className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="p-6 border-b border-gray-100 bg-slate-50/50">
+        <h2 className="text-xl font-bold text-gray-800 tracking-tight">Placement Report (by Domain)</h2>
+        <p className="text-sm text-gray-500 mt-1">あなたの広告が表示された媒体社別のパフォーマンス統計です。</p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Publisher</th>
+              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Domain</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Impressions</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Clicks</th>
+              <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">CTR</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {placements.map((p) => (
+              <tr key={p.id} className="hover:bg-gray-50 transition-colors text-sm">
+                <td className="px-6 py-4">
+                  <div className="font-bold text-gray-900">{p.name}</div>
+                  <div className="text-[10px] text-gray-400">ID: {p.id}</div>
+                </td>
+                <td className="px-6 py-4">
+                  <span className="px-2 py-1 bg-blue-50 text-blue-600 rounded text-xs font-medium">
+                    {p.domain}
+                  </span>
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-slate-700">
+                  {p.impressions.toLocaleString()}
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-slate-700">
+                  {p.clicks.toLocaleString()}
+                </td>
+                <td className="px-6 py-4 text-center">
+                  <span className="text-blue-600 font-black">
+                    {p.impressions > 0 ? ((p.clicks / p.impressions) * 100).toFixed(2) : '0.00'}%
+                  </span>
+                </td>
+              </tr>
+            ))}
+            {placements.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-6 py-12 text-center text-gray-400 italic font-medium">
+                  No placement data available yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/services/stats.test.ts
+++ b/src/services/stats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import db, { initSchema } from '@/lib/db';
-import { getDailyStats } from './stats';
+import { getDailyStats, getPlacementStats } from './stats';
 
 describe('getDailyStats', () => {
   beforeEach(() => {
@@ -75,5 +75,56 @@ describe('getDailyStats', () => {
     const statsForPub2 = getDailyStats({ publisherId: '2' }) as any[];
     const todayStats2 = statsForPub2.find((s: any) => s.date === today);
     expect(todayStats2?.impressions).toBe(1);
+  });
+});
+
+describe('getPlacementStats', () => {
+  beforeEach(() => {
+    db.exec('DROP TABLE IF EXISTS ad_group_target_publishers');
+    db.exec('DROP TABLE IF EXISTS ad_schedules');
+    db.exec('DROP TABLE IF EXISTS clicks');
+    db.exec('DROP TABLE IF EXISTS impressions');
+    db.exec('DROP TABLE IF EXISTS payouts');
+    db.exec('DROP TABLE IF EXISTS ads');
+    db.exec('DROP TABLE IF EXISTS ad_groups');
+    db.exec('DROP TABLE IF EXISTS campaigns');
+    db.exec('DROP TABLE IF EXISTS publishers');
+    db.exec('DROP TABLE IF EXISTS advertisers');
+    initSchema(db);
+  });
+
+  it('should return placement statistics for an advertiser', () => {
+    // テストデータの投入
+    db.prepare("INSERT INTO advertisers (id, name) VALUES (1, 'Adv 1')").run();
+    db.prepare("INSERT INTO advertisers (id, name) VALUES (2, 'Adv 2')").run();
+    
+    db.prepare("INSERT INTO publishers (id, name, domain) VALUES (1, 'Pub 1', 'p1.com')").run();
+    db.prepare("INSERT INTO publishers (id, name, domain) VALUES (2, 'Pub 2', 'p2.com')").run();
+    
+    db.prepare("INSERT INTO campaigns (id, advertiser_id, name) VALUES (1, 1, 'Camp 1')").run();
+    db.prepare("INSERT INTO ad_groups (id, campaign_id, name) VALUES (1, 1, 'Group 1')").run();
+    db.prepare("INSERT INTO ads (id, ad_group_id, title, target_url) VALUES (1, 1, 'Ad 1', 'http://a1.com')").run();
+
+    // 広告主1のインプレッションとクリック
+    db.prepare('INSERT INTO impressions (ad_id, publisher_id) VALUES (1, 1)').run();
+    db.prepare('INSERT INTO impressions (ad_id, publisher_id) VALUES (1, 1)').run();
+    db.prepare('INSERT INTO impressions (ad_id, publisher_id) VALUES (1, 2)').run();
+    db.prepare('INSERT INTO clicks (ad_id, publisher_id, is_valid, processed) VALUES (1, 1, 1, 1)').run();
+
+    const stats = getPlacementStats('1') as any[];
+    
+    expect(stats).toHaveLength(2);
+    
+    const pub1 = stats.find(s => s.id === 1);
+    expect(pub1?.impressions).toBe(2);
+    expect(pub1?.clicks).toBe(1);
+    
+    const pub2 = stats.find(s => s.id === 2);
+    expect(pub2?.impressions).toBe(1);
+    expect(pub2?.clicks).toBe(0);
+
+    // 他の広告主の結果が含まれないことの確認
+    const statsForAdv2 = getPlacementStats('2') as any[];
+    expect(statsForAdv2).toHaveLength(0);
   });
 });

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -33,3 +33,36 @@ export function getDailyStats(filter: { advertiserId?: string, publisherId?: str
   const queryParams = filter.advertiserId || filter.publisherId ? [...params, ...params] : [];
   return db.prepare(query).all(...queryParams);
 }
+
+export function getPlacementStats(advertiserId: string) {
+  const query = `
+    SELECT 
+      p.id,
+      p.name, 
+      p.domain, 
+      COALESCE(i.imps, 0) as impressions, 
+      COALESCE(c.clicks, 0) as clicks
+    FROM publishers p
+    LEFT JOIN (
+        SELECT publisher_id, COUNT(*) as imps 
+        FROM impressions i
+        JOIN ads a ON i.ad_id = a.id
+        JOIN ad_groups ag ON a.ad_group_id = ag.id
+        JOIN campaigns cp ON ag.campaign_id = cp.id
+        WHERE cp.advertiser_id = ?
+        GROUP BY publisher_id
+    ) i ON p.id = i.publisher_id
+    LEFT JOIN (
+        SELECT publisher_id, COUNT(*) as clicks 
+        FROM clicks c
+        JOIN ads a ON c.ad_id = a.id
+        JOIN ad_groups ag ON a.ad_group_id = ag.id
+        JOIN campaigns cp ON ag.campaign_id = cp.id
+        WHERE cp.advertiser_id = ? AND c.is_valid = 1
+        GROUP BY publisher_id
+    ) c ON p.id = c.publisher_id
+    WHERE i.imps > 0 OR c.clicks > 0
+    ORDER BY impressions DESC
+  `;
+  return db.prepare(query).all(advertiserId, advertiserId);
+}


### PR DESCRIPTION
### 概要
広告主が媒体（パブリッシャー/ドメイン）別の成果を確認できる「配信先別レポート」機能を実装しました。

### 変更内容
1. **統計サービスの拡張 ()**
   - `getPlacementStats(advertiserId)` 関数を追加。パブリッシャー別のインプレッション、クリック、CTRを集計します。
2. **UIコンポーネントの作成 ()**
   - パブリッシャー名、ドメイン、成果数値を表示するテーブルコンポーネントを追加しました。
3. **ダッシュボードへの統合 ()**
   - 広告主ダッシュボードのパフォーマンスチャートの横に、配信先別レポートを表示するようにレイアウトを調整しました。
4. **テストの追加 ()**
   - 新機能のデータ集計が正しいことを検証するテストケースを追加しました。

Close #49