### PR TITLE
feat: サーバーアクションの入力バリデーション (Zod の導入) (#56)

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -7392,7 +7392,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "16.1.6",
         "react": "19.2.3",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -9377,7 +9378,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -3,6 +3,22 @@
 import db from "@/lib/db";
 import { runBillingWorker } from "@/services/billing";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const CompletePayoutSchema = z.object({
+  payout_id: z.coerce.number().int().positive(),
+});
+
+const UpdateRevShareSchema = z.object({
+  publisher_id: z.coerce.number().int().positive(),
+  rev_share: z.coerce.number().min(0).max(1),
+});
+
+const ReviewAdSchema = z.object({
+  ad_id: z.coerce.number().int().positive(),
+  action: z.enum(["approve", "reject"]),
+  rejection_reason: z.string().optional().default(""),
+});
 
 // クリック確定処理（Billing Worker実行）
 export async function processClicks() {
@@ -18,7 +34,16 @@ export async function processClicks() {
 
 // 支払い完了処理
 export async function completePayout(formData: FormData) {
-  const payout_id = formData.get("payout_id") as string;
+  const data = Object.fromEntries(formData.entries());
+  const parsed = CompletePayoutSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid payout data");
+  }
+
+  const { payout_id } = parsed.data;
+
   db.prepare('UPDATE payouts SET status = ?, paid_at = CURRENT_TIMESTAMP WHERE id = ?')
     .run('paid', payout_id);
   revalidatePath("/admin");
@@ -26,18 +51,32 @@ export async function completePayout(formData: FormData) {
 
 // 報酬率の更新
 export async function updateRevShare(formData: FormData) {
-  const publisher_id = formData.get("publisher_id") as string;
-  const rev_share = formData.get("rev_share") as string;
+  const data = Object.fromEntries(formData.entries());
+  const parsed = UpdateRevShareSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid rev_share data");
+  }
+
+  const { publisher_id, rev_share } = parsed.data;
+
   db.prepare('UPDATE publishers SET rev_share = ? WHERE id = ?')
-    .run(parseFloat(rev_share), publisher_id);
+    .run(rev_share, publisher_id);
   revalidatePath("/admin");
 }
 
 // 広告審査
 export async function reviewAd(formData: FormData) {
-  const ad_id = formData.get("ad_id") as string;
-  const action = formData.get("action") as string;
-  const rejection_reason = formData.get("rejection_reason") as string;
+  const data = Object.fromEntries(formData.entries());
+  const parsed = ReviewAdSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid review data");
+  }
+
+  const { ad_id, action, rejection_reason } = parsed.data;
   const status = action === 'approve' ? 'approved' : 'rejected';
   
   db.prepare('UPDATE ads SET status = ?, rejection_reason = ? WHERE id = ?')

--- a/src/app/advertiser/[id]/actions.ts
+++ b/src/app/advertiser/[id]/actions.ts
@@ -2,30 +2,66 @@
 
 import db from "@/lib/db";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+// Zod Schemas
+const CampaignSchema = z.object({
+  advertiser_id: z.coerce.number().int().positive(),
+  name: z.string().min(1, "Name is required").max(100),
+  budget: z.coerce.number().nonnegative().default(0),
+  start_date: z.string().nullable().optional().transform(v => v === "" ? null : v),
+  end_date: z.string().nullable().optional().transform(v => v === "" ? null : v),
+});
+
+const AdGroupSchema = z.object({
+  advertiser_id: z.coerce.number().int().positive(),
+  campaign_id: z.coerce.number().int().positive(),
+  name: z.string().min(1, "Name is required").max(100),
+  max_bid: z.coerce.number().positive("Bid must be greater than 0"),
+  target_device: z.enum(["all", "desktop", "mobile"]),
+  target_publishers: z.array(z.string()).optional().default([]),
+});
+
+const AdSchema = z.object({
+  advertiser_id: z.coerce.number().int().positive(),
+  ad_group_id: z.coerce.number().int().positive(),
+  title: z.string().min(1, "Title is required").max(255),
+  description: z.string().max(1000).optional().default(""),
+  image_url: z.string().url("Must be a valid URL"),
+  target_url: z.string().url("Must be a valid URL"),
+});
 
 // キャンペーン作成
 export async function createCampaign(formData: FormData) {
-  const advertiser_id = formData.get("advertiser_id") as string;
-  const name = formData.get("name") as string;
-  const budget = formData.get("budget") as string;
-  const start_date = formData.get("start_date") as string;
-  const end_date = formData.get("end_date") as string;
+  const data = Object.fromEntries(formData.entries());
+  const parsed = CampaignSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid campaign data");
+  }
+
+  const { advertiser_id, name, budget, start_date, end_date } = parsed.data;
 
   db.prepare('INSERT INTO campaigns (advertiser_id, name, budget, start_date, end_date) VALUES (?, ?, ?, ?, ?)')
-    .run(advertiser_id, name, budget || 0, start_date || null, end_date || null);
+    .run(advertiser_id, name, budget, start_date, end_date);
 
   revalidatePath(`/advertiser/${advertiser_id}`);
 }
 
 // アドグループ作成
 export async function createAdGroup(formData: FormData) {
-  const advertiser_id = formData.get("advertiser_id") as string;
-  const campaign_id = formData.get("campaign_id") as string;
-  const name = formData.get("name") as string;
-  const max_bid = formData.get("max_bid") as string;
-  const target_device = formData.get("target_device") as string;
-  const target_publishers = formData.getAll("target_publishers") as string[];
+  const data = Object.fromEntries(formData.entries());
+  // Handle multiple values for target_publishers
+  data.target_publishers = formData.getAll("target_publishers") as any;
+  const parsed = AdGroupSchema.safeParse(data);
 
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid ad group data");
+  }
+
+  const { advertiser_id, campaign_id, name, max_bid, target_device, target_publishers } = parsed.data;
   const isAll = target_publishers.includes('all') || target_publishers.length === 0;
 
   db.transaction(() => {
@@ -37,7 +73,9 @@ export async function createAdGroup(formData: FormData) {
     if (!isAll) {
       const insertTarget = db.prepare('INSERT INTO ad_group_target_publishers (ad_group_id, publisher_id) VALUES (?, ?)');
       target_publishers.forEach(pubId => {
-        insertTarget.run(adGroupId, pubId);
+        if (pubId !== 'all') {
+          insertTarget.run(adGroupId, parseInt(pubId, 10));
+        }
       });
     }
   })();
@@ -47,12 +85,15 @@ export async function createAdGroup(formData: FormData) {
 
 // 広告作成
 export async function createAd(formData: FormData) {
-  const advertiser_id = formData.get("advertiser_id") as string;
-  const ad_group_id = formData.get("ad_group_id") as string;
-  const title = formData.get("title") as string;
-  const description = formData.get("description") as string;
-  const image_url = formData.get("image_url") as string;
-  const target_url = formData.get("target_url") as string;
+  const data = Object.fromEntries(formData.entries());
+  const parsed = AdSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid ad data");
+  }
+
+  const { advertiser_id, ad_group_id, title, description, image_url, target_url } = parsed.data;
 
   db.prepare('INSERT INTO ads (ad_group_id, title, description, image_url, target_url, status) VALUES (?, ?, ?, ?, ?, ?)')
     .run(ad_group_id, title, description, image_url, target_url, 'pending');
@@ -62,29 +103,40 @@ export async function createAd(formData: FormData) {
 
 // キャンペーン更新
 export async function updateCampaign(formData: FormData) {
-  const id = formData.get("id") as string;
-  const advertiser_id = formData.get("advertiser_id") as string;
-  const name = formData.get("name") as string;
-  const budget = formData.get("budget") as string;
-  const start_date = formData.get("start_date") as string;
-  const end_date = formData.get("end_date") as string;
+  const data = Object.fromEntries(formData.entries());
+  const id = parseInt(data.id as string, 10);
+  if (isNaN(id)) throw new Error("Invalid campaign ID");
+
+  const parsed = CampaignSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid campaign data");
+  }
+
+  const { advertiser_id, name, budget, start_date, end_date } = parsed.data;
 
   db.prepare('UPDATE campaigns SET name = ?, budget = ?, start_date = ?, end_date = ? WHERE id = ?')
-    .run(name, budget, start_date, end_date || null, id);
+    .run(name, budget, start_date, end_date, id);
 
   revalidatePath(`/advertiser/${advertiser_id}`);
 }
 
 // アドグループ更新
 export async function updateAdGroup(formData: FormData) {
-  const id = formData.get("id") as string;
-  const advertiser_id = formData.get("advertiser_id") as string;
-  const campaign_id = formData.get("campaign_id") as string;
-  const name = formData.get("name") as string;
-  const max_bid = formData.get("max_bid") as string;
-  const target_device = formData.get("target_device") as string;
-  const target_publishers = formData.getAll("target_publishers") as string[];
+  const data = Object.fromEntries(formData.entries());
+  const id = parseInt(data.id as string, 10);
+  if (isNaN(id)) throw new Error("Invalid ad group ID");
 
+  data.target_publishers = formData.getAll("target_publishers") as any;
+  const parsed = AdGroupSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid ad group data");
+  }
+
+  const { advertiser_id, campaign_id, name, max_bid, target_device, target_publishers } = parsed.data;
   const isAll = target_publishers.includes('all') || target_publishers.length === 0;
 
   db.transaction(() => {
@@ -97,7 +149,9 @@ export async function updateAdGroup(formData: FormData) {
     if (!isAll) {
       const insertTarget = db.prepare('INSERT INTO ad_group_target_publishers (ad_group_id, publisher_id) VALUES (?, ?)');
       target_publishers.forEach(pubId => {
-        insertTarget.run(id, pubId);
+        if (pubId !== 'all') {
+          insertTarget.run(id, parseInt(pubId, 10));
+        }
       });
     }
   })();
@@ -107,13 +161,18 @@ export async function updateAdGroup(formData: FormData) {
 
 // 広告更新 (再審査ロジック付き)
 export async function updateAd(formData: FormData) {
-  const id = formData.get("id") as string;
-  const advertiser_id = formData.get("advertiser_id") as string;
-  const ad_group_id = formData.get("ad_group_id") as string;
-  const title = formData.get("title") as string;
-  const description = formData.get("description") as string;
-  const image_url = formData.get("image_url") as string;
-  const target_url = formData.get("target_url") as string;
+  const data = Object.fromEntries(formData.entries());
+  const id = parseInt(data.id as string, 10);
+  if (isNaN(id)) throw new Error("Invalid ad ID");
+
+  const parsed = AdSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    throw new Error("Invalid ad data");
+  }
+
+  const { advertiser_id, ad_group_id, title, description, image_url, target_url } = parsed.data;
 
   // 現在のデータを取得して変更があるか確認
   const current = db.prepare('SELECT * FROM ads WHERE id = ?').get(id) as any;

--- a/src/app/publisher/[id]/actions.ts
+++ b/src/app/publisher/[id]/actions.ts
@@ -2,9 +2,22 @@
 
 import db from "@/lib/db";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const PayoutRequestSchema = z.object({
+  publisher_id: z.coerce.number().int().positive(),
+});
 
 export async function requestPayout(formData: FormData) {
-  const publisherId = formData.get("publisher_id") as string;
+  const data = Object.fromEntries(formData.entries());
+  const parsed = PayoutRequestSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    return { success: false, error: "Invalid publisher ID" };
+  }
+
+  const publisherId = parsed.data.publisher_id;
   const publisher = db.prepare('SELECT balance FROM publishers WHERE id = ?').get(publisherId) as any;
 
   if (publisher && publisher.balance >= 1000) {


### PR DESCRIPTION
### 概要
広告主や管理者がデータを作成・更新する際のサーバーアクション (`actions.ts`) に対して、`zod` を使用した厳格な入力バリデーションを追加しました。
これにより、不正なデータ（マイナスの入札額や無効なURLなど）がデータベースに保存されるのを未然に防ぐことができます。

### 変更内容
1. **`zod` パッケージの導入**: `package.json` に依存関係を追加しました。
2. **広告主向けアクション (`src/app/advertiser/[id]/actions.ts`)**:
   - `CampaignSchema`, `AdGroupSchema`, `AdSchema` を定義し、作成・更新時にデータを検証。
   - 数値の強制変換 (`z.coerce.number()`) や、文字列の長さ制限、URL形式の検証を実装。
3. **管理者向けアクション (`src/app/admin/actions.ts`)**:
   - 報酬率の範囲（0.0 〜 1.0）や、アクションの列挙型 (`approve` | `reject`) を検証。
4. **パブリッシャー向けアクション (`src/app/publisher/[id]/actions.ts`)**:
   - `publisher_id` のフォーマットを検証。

Close #56