### PR TITLE
feat: implement contextual matching based on publisher categories (fixes #80)

### DIFF
--- a/prisma/migrations/20260316130012_add_category_matching/migration.sql
+++ b/prisma/migrations/20260316130012_add_category_matching/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ad_groups" ADD COLUMN "target_category" TEXT;
+
+-- AlterTable
+ALTER TABLE "publishers" ADD COLUMN "category" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Publisher {
   id             Int                        @id @default(autoincrement())
   name           String
   domain         String
+  category       String?
   balance        Float                      @default(0)
   total_earnings Float                      @default(0)
   rev_share      Float                      @default(0.7)
@@ -90,6 +91,7 @@ model AdGroup {
   name              String
   max_bid           Float                      @default(10)
   target_device     String                     @default("all")
+  target_category   String?
   is_all_publishers Int                        @default(1) // 1: All, 0: Specific
   campaign          Campaign                   @relation(fields: [campaign_id], references: [id])
   schedules         AdSchedule[]

--- a/src/app/advertiser/[id]/actions.ts
+++ b/src/app/advertiser/[id]/actions.ts
@@ -29,6 +29,7 @@ const AdGroupSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   max_bid: z.coerce.number().positive("Bid must be greater than 0"),
   target_device: z.enum(["all", "desktop", "mobile"]),
+  target_category: z.string().optional().nullable().transform(v => v === "" ? null : v),
   target_publishers: z.array(z.string()).optional().default([]),
 });
 
@@ -79,7 +80,7 @@ export async function createAdGroup(formData: FormData) {
     throw new Error("Invalid ad group data");
   }
 
-  const { advertiser_id, campaign_id, name, max_bid, target_device, target_publishers } = parsed.data;
+  const { advertiser_id, campaign_id, name, max_bid, target_device, target_category, target_publishers } = parsed.data;
   await checkAuth(advertiser_id);
 
   const isAll = target_publishers.includes('all') || target_publishers.length === 0;
@@ -91,6 +92,7 @@ export async function createAdGroup(formData: FormData) {
         name,
         max_bid,
         target_device,
+        target_category,
         is_all_publishers: isAll ? 1 : 0,
       }
     });
@@ -183,7 +185,7 @@ export async function updateAdGroup(formData: FormData) {
     throw new Error("Invalid ad group data");
   }
 
-  const { advertiser_id, campaign_id, name, max_bid, target_device, target_publishers } = parsed.data;
+  const { advertiser_id, campaign_id, name, max_bid, target_device, target_category, target_publishers } = parsed.data;
   await checkAuth(advertiser_id);
 
   const isAll = target_publishers.includes('all') || target_publishers.length === 0;
@@ -196,6 +198,7 @@ export async function updateAdGroup(formData: FormData) {
         name,
         max_bid,
         target_device,
+        target_category,
         is_all_publishers: isAll ? 1 : 0,
       }
     });

--- a/src/app/advertiser/[id]/page.tsx
+++ b/src/app/advertiser/[id]/page.tsx
@@ -199,9 +199,22 @@ export default async function AdvertiserDashboard({ params }: PageProps) {
                 <label className="block text-sm font-bold text-gray-700 mb-1">Group Name</label>
                 <input type="text" name="name" className="w-full p-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-emerald-100 outline-none" placeholder="e.g. Mobile Users" required />
               </div>
-              <div>
-                <label className="block text-sm font-bold text-gray-700 mb-1">Max Bid (¥)</label>
-                <input type="number" name="max_bid" className="w-full p-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-emerald-100 outline-none" placeholder="50" required />
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-bold text-gray-700 mb-1">Max Bid (¥)</label>
+                  <input type="number" name="max_bid" className="w-full p-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-emerald-100 outline-none" placeholder="50" required />
+                </div>
+                <div>
+                  <label className="block text-sm font-bold text-gray-700 mb-1">Target Category</label>
+                  <select name="target_category" className="w-full p-2 border border-gray-200 rounded-lg bg-white outline-none focus:ring-2 focus:ring-emerald-100">
+                    <option value="">Any Category</option>
+                    <option value="anime">Anime & Manga</option>
+                    <option value="game">Games</option>
+                    <option value="tech">Technology</option>
+                    <option value="lifestyle">Lifestyle</option>
+                    <option value="business">Business</option>
+                  </select>
+                </div>
               </div>
               <div>
                 <label className="block text-xs uppercase tracking-wider font-black text-gray-400 mb-2">Target Device</label>

--- a/src/app/api/serve/route.test.ts
+++ b/src/app/api/serve/route.test.ts
@@ -154,4 +154,49 @@ describe('GET /api/serve', () => {
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
     expect(html).toContain('&quot; onclick=&quot;alert(2)');
   });
+
+  describe('Category Matching', () => {
+    beforeEach(async () => {
+      // Publisher 2 (Anime) and Publisher 3 (Tech)
+      await prisma.publisher.create({ data: { id: 2, name: 'Pub Anime', domain: 'anime.com', category: 'anime' } });
+      await prisma.publisher.create({ data: { id: 3, name: 'Pub Tech', domain: 'tech.com', category: 'tech' } });
+    });
+
+    it('should serve an ad when categories match (Anime)', async () => {
+      await prisma.adGroup.update({ where: { id: 1 }, data: { target_category: 'anime' } });
+
+      const req = new NextRequest('http://localhost/api/serve?publisher_id=2');
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('Ad 1');
+    });
+
+    it('should NOT serve an ad when categories mismatch (Anime vs Tech)', async () => {
+      await prisma.adGroup.update({ where: { id: 1 }, data: { target_category: 'anime' } });
+
+      const req = new NextRequest('http://localhost/api/serve?publisher_id=3');
+      const res = await GET(req);
+      expect(res.status).toBe(204);
+    });
+
+    it('should serve an ad when target_category is NULL (broad matching)', async () => {
+      await prisma.adGroup.update({ where: { id: 1 }, data: { target_category: null } });
+
+      // Request from Tech publisher
+      const req = new NextRequest('http://localhost/api/serve?publisher_id=3');
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('Ad 1');
+    });
+
+    it('should serve an ad when target_category is empty string (broad matching)', async () => {
+      await prisma.adGroup.update({ where: { id: 1 }, data: { target_category: '' } });
+
+      const req = new NextRequest('http://localhost/api/serve?publisher_id=2');
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+    });
+  });
 });

--- a/src/app/api/serve/route.tsx
+++ b/src/app/api/serve/route.tsx
@@ -36,8 +36,15 @@ export async function GET(req: NextRequest) {
       JOIN ad_groups ON ads.ad_group_id = ad_groups.id
       JOIN campaigns ON ad_groups.campaign_id = campaigns.id
       JOIN advertisers ON campaigns.advertiser_id = advertisers.id
+      JOIN publishers ON publishers.id = ${publisherId}
       WHERE ads.status = 'approved'
         AND advertisers.balance >= ad_groups.max_bid
+        -- カテゴリマッチング
+        AND (
+          ad_groups.target_category IS NULL 
+          OR ad_groups.target_category = ''
+          OR ad_groups.target_category = publishers.category
+        )
         -- キャンペーン予算チェック (Total)
         AND (campaigns.budget = 0 OR campaigns.spent < campaigns.budget)
         -- キャンペーン予算チェック (Daily)

--- a/src/app/publisher/[id]/actions.ts
+++ b/src/app/publisher/[id]/actions.ts
@@ -9,6 +9,38 @@ const PayoutRequestSchema = z.object({
   publisher_id: z.coerce.number().int().positive(),
 });
 
+const ProfileUpdateSchema = z.object({
+  publisher_id: z.coerce.number().int().positive(),
+  category: z.string().optional().nullable().transform(v => v === "" ? null : v),
+});
+
+export async function updatePublisherProfile(formData: FormData) {
+  const data = Object.fromEntries(formData.entries());
+  const parsed = ProfileUpdateSchema.safeParse(data);
+
+  if (!parsed.success) {
+    console.error(parsed.error.issues);
+    return { success: false, error: "Invalid profile data" };
+  }
+
+  const { publisher_id, category } = parsed.data;
+  const session = await auth();
+  const user = session?.user as any;
+
+  // Authorization check
+  if (user?.role !== 'admin' && (user?.role !== 'publisher' || user?.linked_id !== publisher_id)) {
+    return { success: false, error: "Forbidden: Access denied" };
+  }
+
+  await prisma.publisher.update({
+    where: { id: publisher_id },
+    data: { category }
+  });
+
+  revalidatePath(`/publisher/${publisher_id}`);
+  return { success: true };
+}
+
 export async function requestPayout(formData: FormData) {
   const data = Object.fromEntries(formData.entries());
   const parsed = PayoutRequestSchema.safeParse(data);

--- a/src/app/publisher/[id]/page.tsx
+++ b/src/app/publisher/[id]/page.tsx
@@ -3,7 +3,7 @@ import { getDailyStats } from "@/services/stats";
 import Link from "next/link";
 import { notFound, forbidden } from "next/navigation";
 import StatsChart from "@/components/StatsChart";
-import { requestPayout } from "./actions";
+import { requestPayout, updatePublisherProfile } from "./actions";
 import { auth } from "@/auth";
 
 export const dynamic = "force-dynamic";
@@ -88,8 +88,38 @@ export default async function PublisherDashboard({ params }: PageProps) {
         </section>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
-          {/* Payout Section */}
+          {/* Profile Settings & Payout */}
           <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-100">
+            <h2 className="text-xl font-bold mb-4 text-gray-800">Profile Settings</h2>
+            <form action={async (formData) => {
+              "use server";
+              await updatePublisherProfile(formData);
+            }} className="flex flex-col gap-4 mb-8">
+              <input type="hidden" name="publisher_id" value={publisher.id} />
+              <div>
+                <label className="block text-sm font-bold text-gray-700 mb-1">Publisher Category</label>
+                <p className="text-xs text-gray-500 mb-2">広告のコンテキストマッチングに使用されます。あなたのサイトの主ジャンルを選んでください。</p>
+                <select 
+                  name="category" 
+                  defaultValue={publisher.category || ""}
+                  className="w-full p-2 border border-gray-200 rounded-lg bg-white outline-none focus:ring-2 focus:ring-emerald-100 text-slate-900 font-medium"
+                >
+                  <option value="">Any Category</option>
+                  <option value="anime">Anime & Manga</option>
+                  <option value="game">Games</option>
+                  <option value="tech">Technology</option>
+                  <option value="lifestyle">Lifestyle</option>
+                  <option value="business">Business</option>
+                </select>
+              </div>
+              <button
+                type="submit"
+                className="w-full py-2 px-4 rounded-lg font-bold bg-blue-600 hover:bg-blue-700 text-white shadow-md transition-colors"
+              >
+                Save Settings
+              </button>
+            </form>
+
             <h2 className="text-xl font-bold mb-4 text-gray-800">Payout</h2>
             <div className="bg-gray-50 p-4 rounded-lg flex flex-col gap-4">
               <div>

--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -82,6 +82,17 @@ export default function EditModal({ isOpen, onClose, advertiserId, type, data, c
                 <input type="number" name="max_bid" defaultValue={data.max_bid} className="w-full p-2 border rounded-lg outline-none focus:ring-2 focus:ring-emerald-100 text-slate-900 font-medium font-mono" required />
               </div>
               <div>
+                <label className="block text-sm font-bold text-gray-700 mb-1">Target Category</label>
+                <select name="target_category" defaultValue={data.target_category || ""} className="w-full p-2 border rounded-lg outline-none focus:ring-2 focus:ring-emerald-100 bg-white text-slate-900 font-medium">
+                  <option value="">Any Category</option>
+                  <option value="anime">Anime & Manga</option>
+                  <option value="game">Games</option>
+                  <option value="tech">Technology</option>
+                  <option value="lifestyle">Lifestyle</option>
+                  <option value="business">Business</option>
+                </select>
+              </div>
+              <div>
                 <label className="block text-xs font-bold text-gray-400 uppercase mb-2">Target Device</label>
                 <div className="flex gap-4">
                   {['all', 'desktop', 'mobile'].map(d => (

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -46,9 +46,9 @@ async function seed() {
 
   // 3. Publishers (Triggering trend branches)
   const publishers = [
-    { id: 1, name: 'Growth Media (Up Trend)', domain: 'growth.com', rev_share: 0.7, balance: 80000 },
-    { id: 2, name: 'Declining Blog (Down Trend)', domain: 'decline.jp', rev_share: 0.8, balance: 15000 },
-    { id: 3, name: 'New Publisher (No stats)', domain: 'new.net', rev_share: 0.6, balance: 0 },
+    { id: 1, name: 'Growth Media (Up Trend)', domain: 'growth.com', rev_share: 0.7, balance: 80000, category: 'anime' },
+    { id: 2, name: 'Declining Blog (Down Trend)', domain: 'decline.jp', rev_share: 0.8, balance: 15000, category: 'game' },
+    { id: 3, name: 'New Publisher (No stats)', domain: 'new.net', rev_share: 0.6, balance: 0, category: 'tech' },
   ];
   for (const p of publishers) {
     await prisma.publisher.create({ data: p });
@@ -75,8 +75,17 @@ async function seed() {
   }
 
   // 6. Ad Groups
+  const categories = [null, 'anime', 'game', 'tech', 'lifestyle', 'business'];
   for (const c of campaigns) {
-    await prisma.adGroup.create({ data: { id: c.id, campaign_id: c.id, name: `${c.name} Group`, max_bid: 100 } });
+    await prisma.adGroup.create({ 
+      data: { 
+        id: c.id, 
+        campaign_id: c.id, 
+        name: `${c.name} Group`, 
+        max_bid: 100,
+        target_category: categories[c.id - 1] || null
+      } 
+    });
   }
 
   // 7. Ads (Triggering status branches)


### PR DESCRIPTION
### Objective
Introduce category-based matching between publishers and advertisers to improve ad relevance.

### Changes
- Database Schema: Added category to Publisher and target_category to AdGroup.
- Publisher Dashboard: Added a new Profile Settings section for publishers to select their site category.
- Advertiser UI: Updated ad group forms and server actions to support targeting categories.
- Ad Serving Logic: Modified the SQL query in route.tsx to filter ads based on category matching (broad matching is preserved if target category is not set).
- Testing: Added new test cases in route.test.ts to verify matching logic.

Fixes #80