### PR TITLE
feat: integrate conversion analytics into all advertiser reports (Ads, Placements, Campaigns, Groups)

### DIFF
--- a/src/app/advertiser/[id]/page.tsx
+++ b/src/app/advertiser/[id]/page.tsx
@@ -45,19 +45,60 @@ export default async function AdvertiserDashboard({ params }: PageProps) {
   const advertiserInsights = await getAdvertiserInsights(id);
 
   // キャンペーン一覧の取得
-  const campaigns = await prisma.campaign.findMany({
-    where: { advertiser_id: id }
+  const campaignsRaw = await prisma.campaign.findMany({
+    where: { advertiser_id: id },
+    include: {
+      clicks: {
+        where: { is_valid: 1 },
+        select: {
+          conversions: {
+            select: {
+              revenue: true
+            }
+          }
+        }
+      }
+    }
+  });
+  const campaigns = campaignsRaw.map(c => {
+    const conversions = c.clicks.flatMap(cl => cl.conversions);
+    return {
+      ...c,
+      conversions: conversions.length,
+      revenue: conversions.reduce((acc, curr) => acc + curr.revenue, 0)
+    };
   });
   
   // アドグループ一覧の取得 (キャンペーン名を含む)
   const adGroupsRaw = await prisma.adGroup.findMany({
     where: { campaign: { advertiser_id: id } },
-    include: { campaign: { select: { name: true } } }
+    include: { 
+      campaign: { select: { name: true } },
+      ads: {
+        include: {
+          clicks: {
+            where: { is_valid: 1 },
+            select: {
+              conversions: {
+                select: {
+                  revenue: true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   });
-  const adGroups = adGroupsRaw.map(g => ({
-    ...g,
-    campaign_name: g.campaign.name
-  }));
+  const adGroups = adGroupsRaw.map(g => {
+    const conversions = g.ads.flatMap(ad => ad.clicks.flatMap(cl => cl.conversions));
+    return {
+      ...g,
+      campaign_name: g.campaign.name,
+      conversions: conversions.length,
+      revenue: conversions.reduce((acc, curr) => acc + curr.revenue, 0)
+    };
+  });
 
   // 広告成果一覧の取得
   const adsRaw = await prisma.ad.findMany({
@@ -75,24 +116,42 @@ export default async function AdvertiserDashboard({ params }: PageProps) {
             where: { is_valid: 1 }
           }
         }
+      },
+      clicks: {
+        where: { is_valid: 1 },
+        select: {
+          conversions: {
+            select: {
+              revenue: true
+            }
+          }
+        }
       }
     },
     orderBy: { id: 'desc' }
   });
 
-  const ads = adsRaw.map(ad => ({
-    ...ad,
-    group_name: ad.adGroup.name,
-    max_bid: ad.adGroup.max_bid,
-    target_device: ad.adGroup.target_device,
-    campaign_name: ad.adGroup.campaign.name,
-    campaign_id: ad.adGroup.campaign.id,
-    start_date: ad.adGroup.campaign.start_date,
-    end_date: ad.adGroup.campaign.end_date,
-    campaign_budget: ad.adGroup.campaign.budget,
-    impressions: ad._count.impressions,
-    clicks: ad._count.clicks
-  }));
+  const ads = adsRaw.map(ad => {
+    const conversions = ad.clicks.flatMap(c => c.conversions);
+    const cvCount = conversions.length;
+    const cvRevenue = conversions.reduce((acc, curr) => acc + curr.revenue, 0);
+
+    return {
+      ...ad,
+      group_name: ad.adGroup.name,
+      max_bid: ad.adGroup.max_bid,
+      target_device: ad.adGroup.target_device,
+      campaign_name: ad.adGroup.campaign.name,
+      campaign_id: ad.adGroup.campaign.id,
+      start_date: ad.adGroup.campaign.start_date,
+      end_date: ad.adGroup.campaign.end_date,
+      campaign_budget: ad.adGroup.campaign.budget,
+      impressions: ad._count.impressions,
+      clicks: ad._count.clicks,
+      conversions: cvCount,
+      revenue: cvRevenue
+    };
+  });
 
   const dailyStats = await getDailyStats({ advertiserId: id.toString() }) as any[];
   const placementStats = await getPlacementStats(id.toString()) as any[];

--- a/src/components/AdGroupsTable.tsx
+++ b/src/components/AdGroupsTable.tsx
@@ -10,6 +10,8 @@ interface AdGroup {
   name: string;
   max_bid: number;
   target_device: string;
+  conversions: number;
+  revenue: number;
 }
 
 interface AdGroupsTableProps {
@@ -32,16 +34,18 @@ export default function AdGroupsTable({ adGroups, campaigns, advertiserId }: AdG
         campaigns={campaigns}
       />
       <div className="p-6 border-b border-gray-100 bg-slate-50/50 flex justify-between items-center">
-        <h2 className="text-xl font-bold text-gray-800 tracking-tight">Ad Groups</h2>
+        <h2 className="text-xl font-bold text-gray-800 tracking-tight">Ad Groups Performance</h2>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
+        <table className="min-w-full border-collapse">
           <thead className="bg-gray-50">
             <tr>
               <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Name</th>
               <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Campaign</th>
-              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest text-right">Max Bid</th>
-              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest text-center">Device</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Max Bid</th>
+              <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">Device</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-blue-400 uppercase tracking-widest">CV</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-emerald-400 uppercase tracking-widest">Revenue</th>
               <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">Actions</th>
             </tr>
           </thead>
@@ -49,16 +53,30 @@ export default function AdGroupsTable({ adGroups, campaigns, advertiserId }: AdG
             {adGroups.map((g) => (
               <tr key={g.id} className="hover:bg-gray-50 transition-colors text-sm">
                 <td className="px-6 py-4 font-bold text-gray-900">{g.name}</td>
-                <td className="px-6 py-4 text-gray-600 italic">{g.campaign_name}</td>
+                <td className="px-6 py-4 text-gray-600 italic text-xs">{g.campaign_name}</td>
                 <td className="px-6 py-4 text-right font-mono font-bold text-slate-700">¥{g.max_bid}</td>
                 <td className="px-6 py-4 text-center">
                   <span className="px-2 py-0.5 bg-slate-100 text-slate-500 rounded text-[10px] font-bold uppercase">{g.target_device}</span>
                 </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-blue-700">
+                  {g.conversions.toLocaleString()}
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-emerald-700">
+                  ¥{g.revenue.toLocaleString()}
+                </td>
                 <td className="px-6 py-4 text-center">
-                  <button onClick={() => setEditModal({ isOpen: true, data: g })} className="text-blue-600 hover:text-blue-800 font-bold text-[10px] uppercase">Edit</button>
+                  <button 
+                    onClick={() => setEditModal({ isOpen: true, data: g })} 
+                    className="bg-blue-50 text-blue-600 hover:bg-blue-100 px-3 py-1.5 rounded-lg font-bold text-[10px] uppercase transition-colors"
+                  >
+                    Edit
+                  </button>
                 </td>
               </tr>
             ))}
+            {adGroups.length === 0 && (
+              <tr><td colSpan={7} className="px-6 py-12 text-center text-gray-400 italic">No ad groups found.</td></tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/components/AdsPerformanceTable.tsx
+++ b/src/components/AdsPerformanceTable.tsx
@@ -12,6 +12,8 @@ interface AdPerformance {
   rejection_reason?: string | null;
   impressions: number;
   clicks: number;
+  conversions: number;
+  revenue: number;
   campaign_id: number;
   ad_group_id: number;
   group_name: string;
@@ -37,12 +39,13 @@ const COLUMN_LABELS: Record<string, string> = {
   bid: "Max Bid",
   device: "Device",
   targetUrl: "Target URL",
-  stats: "Stats",
+  stats: "Stats (Click)",
+  conversion: "Conversions",
 };
 
 export default function AdsPerformanceTable({ ads, adGroups, advertiserId }: AdsPerformanceTableProps) {
   const [visibleColumns, setVisibleColumns] = useState<Set<string>>(
-    new Set(["adGroup", "stats"])
+    new Set(["adGroup", "stats", "conversion"])
   );
   const [showColumnSelector, setShowColumnSelector] = useState(false);
 
@@ -123,6 +126,14 @@ export default function AdsPerformanceTable({ ads, adGroups, advertiserId }: Ads
                   <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">CTR</th>
                 </>
               )}
+              {visibleColumns.has("conversion") && (
+                <>
+                  <th className="px-6 py-3 text-right text-xs font-bold text-blue-400 uppercase tracking-widest">CV</th>
+                  <th className="px-6 py-3 text-center text-xs font-bold text-blue-400 uppercase tracking-widest">CVR</th>
+                  <th className="px-6 py-3 text-right text-xs font-bold text-emerald-400 uppercase tracking-widest text-nowrap">CPA</th>
+                  <th className="px-6 py-3 text-right text-xs font-bold text-emerald-400 uppercase tracking-widest">Revenue</th>
+                </>
+              )}
               <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest sticky right-0 bg-gray-50 z-10 border-l border-gray-100">Actions</th>
             </tr>
           </thead>
@@ -175,6 +186,18 @@ export default function AdsPerformanceTable({ ads, adGroups, advertiserId }: Ads
                     <td className="px-6 py-4 text-center text-blue-600 font-black">
                       {ad.impressions > 0 ? ((ad.clicks / ad.impressions) * 100).toFixed(2) : '0.00'}%
                     </td>
+                  </>
+                )}
+                {visibleColumns.has("conversion") && (
+                  <>
+                    <td className="px-6 py-4 text-right font-mono font-bold text-blue-700">{ad.conversions.toLocaleString()}</td>
+                    <td className="px-6 py-4 text-center text-blue-600 font-black">
+                      {ad.clicks > 0 ? ((ad.conversions / ad.clicks) * 100).toFixed(2) : '0.00'}%
+                    </td>
+                    <td className="px-6 py-4 text-right font-mono font-bold text-emerald-700">
+                      {ad.conversions > 0 ? `¥${Math.floor((ad.clicks * ad.max_bid) / ad.conversions).toLocaleString()}` : '-'}
+                    </td>
+                    <td className="px-6 py-4 text-right font-mono font-bold text-emerald-700">¥{ad.revenue.toLocaleString()}</td>
                   </>
                 )}
                 <td className="px-6 py-4 text-center sticky right-0 bg-white z-10 border-l border-gray-100 shadow-[-4px_0_6px_-2px_rgba(0,0,0,0.05)]">

--- a/src/components/CampaignsTable.tsx
+++ b/src/components/CampaignsTable.tsx
@@ -10,9 +10,14 @@ interface Campaign {
   daily_budget: number;
   start_date: string | Date;
   end_date?: string | Date | null;
+  conversions: number;
+  revenue: number;
 }
 
-// ... (interface CampaignsTableProps unchanged)
+interface CampaignsTableProps {
+  campaigns: Campaign[];
+  advertiserId: string;
+}
 
 export default function CampaignsTable({ campaigns, advertiserId }: CampaignsTableProps) {
   const [editModal, setEditModal] = useState<{ isOpen: boolean; data: any }>({ isOpen: false, data: null });
@@ -27,15 +32,17 @@ export default function CampaignsTable({ campaigns, advertiserId }: CampaignsTab
         data={editModal.data}
       />
       <div className="p-6 border-b border-gray-100 bg-slate-50/50 flex justify-between items-center">
-        <h2 className="text-xl font-bold text-gray-800 tracking-tight">Campaigns</h2>
+        <h2 className="text-xl font-bold text-gray-800 tracking-tight">Campaigns Performance</h2>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
+        <table className="min-w-full border-collapse">
           <thead className="bg-gray-50">
             <tr>
               <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Name</th>
-              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest text-right">Budget (Total / Daily)</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Budget (Total / Daily)</th>
               <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Duration</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-blue-400 uppercase tracking-widest">CV</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-emerald-400 uppercase tracking-widest">Revenue</th>
               <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">Actions</th>
             </tr>
           </thead>
@@ -51,12 +58,25 @@ export default function CampaignsTable({ campaigns, advertiserId }: CampaignsTab
                   <div className="font-bold">{new Date(c.start_date).toLocaleDateString('ja-JP')}</div>
                   <div className="text-[10px]">to {c.end_date ? new Date(c.end_date).toLocaleDateString('ja-JP') : 'Endless'}</div>
                 </td>
-
+                <td className="px-6 py-4 text-right font-mono font-bold text-blue-700">
+                  {c.conversions.toLocaleString()}
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-emerald-700">
+                  ¥{c.revenue.toLocaleString()}
+                </td>
                 <td className="px-6 py-4 text-center">
-                  <button onClick={() => setEditModal({ isOpen: true, data: c })} className="text-blue-600 hover:text-blue-800 font-bold text-[10px] uppercase">Edit</button>
+                  <button 
+                    onClick={() => setEditModal({ isOpen: true, data: c })} 
+                    className="bg-blue-50 text-blue-600 hover:bg-blue-100 px-3 py-1.5 rounded-lg font-bold text-[10px] uppercase transition-colors"
+                  >
+                    Edit
+                  </button>
                 </td>
               </tr>
             ))}
+            {campaigns.length === 0 && (
+              <tr><td colSpan={6} className="px-6 py-12 text-center text-gray-400 italic">No campaigns found.</td></tr>
+            )}
           </tbody>
         </table>
       </div>

--- a/src/components/PlacementReportTable.tsx
+++ b/src/components/PlacementReportTable.tsx
@@ -4,6 +4,9 @@ interface PlacementStat {
   domain: string;
   impressions: number;
   clicks: number;
+  cost: number;
+  conversions: number;
+  revenue: number;
 }
 
 interface PlacementReportTableProps {
@@ -21,24 +24,22 @@ export default function PlacementReportTable({ placements }: PlacementReportTabl
         <table className="min-w-full border-collapse">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Publisher</th>
-              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest">Domain</th>
-              <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Impressions</th>
+              <th className="px-6 py-3 text-left text-xs font-bold text-gray-400 uppercase tracking-widest sticky left-0 bg-gray-50 z-10 border-r border-gray-100">Publisher</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Imps</th>
               <th className="px-6 py-3 text-right text-xs font-bold text-gray-400 uppercase tracking-widest">Clicks</th>
               <th className="px-6 py-3 text-center text-xs font-bold text-gray-400 uppercase tracking-widest">CTR</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-blue-400 uppercase tracking-widest">CV</th>
+              <th className="px-6 py-3 text-center text-xs font-bold text-blue-400 uppercase tracking-widest">CVR</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-emerald-400 uppercase tracking-widest">CPA</th>
+              <th className="px-6 py-3 text-right text-xs font-bold text-emerald-400 uppercase tracking-widest">Revenue</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {placements.map((p) => (
               <tr key={p.id} className="hover:bg-gray-50 transition-colors text-sm">
-                <td className="px-6 py-4">
-                  <div className="font-bold text-gray-900">{p.name}</div>
-                  <div className="text-[10px] text-gray-400">ID: {p.id}</div>
-                </td>
-                <td className="px-6 py-4">
-                  <span className="px-2 py-1 bg-blue-50 text-blue-600 rounded text-xs font-medium">
-                    {p.domain}
-                  </span>
+                <td className="px-6 py-4 sticky left-0 bg-white z-10 border-r border-gray-100">
+                  <div className="font-bold text-gray-900 leading-tight">{p.name}</div>
+                  <div className="text-[10px] text-gray-400">{p.domain}</div>
                 </td>
                 <td className="px-6 py-4 text-right font-mono font-bold text-slate-700">
                   {p.impressions.toLocaleString()}
@@ -47,15 +48,29 @@ export default function PlacementReportTable({ placements }: PlacementReportTabl
                   {p.clicks.toLocaleString()}
                 </td>
                 <td className="px-6 py-4 text-center">
-                  <span className="text-blue-600 font-black">
+                  <span className="text-gray-600 font-bold">
                     {p.impressions > 0 ? ((p.clicks / p.impressions) * 100).toFixed(2) : '0.00'}%
                   </span>
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-blue-700">
+                  {p.conversions.toLocaleString()}
+                </td>
+                <td className="px-6 py-4 text-center">
+                  <span className="text-blue-600 font-black">
+                    {p.clicks > 0 ? ((p.conversions / p.clicks) * 100).toFixed(2) : '0.00'}%
+                  </span>
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-emerald-700">
+                  {p.conversions > 0 ? `¥${Math.floor(p.cost / p.conversions).toLocaleString()}` : '-'}
+                </td>
+                <td className="px-6 py-4 text-right font-mono font-bold text-emerald-700">
+                  ¥{p.revenue.toLocaleString()}
                 </td>
               </tr>
             ))}
             {placements.length === 0 && (
               <tr>
-                <td colSpan={5} className="px-6 py-12 text-center text-gray-400 italic font-medium">
+                <td colSpan={8} className="px-6 py-12 text-center text-gray-400 italic font-medium">
                   No placement data available yet.
                 </td>
               </tr>

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -80,7 +80,7 @@ export async function getDailyStats(filter: { advertiserId?: string, publisherId
 export async function getPlacementStats(advertiserId: string) {
   const advId = parseInt(advertiserId, 10);
   
-  // Placement stats still benefit from a join, but let's see if we can do it with Prisma findMany
+  // Placement stats with Conversions
   const publishers = await prisma.publisher.findMany({
     where: {
       OR: [
@@ -98,15 +98,39 @@ export async function getPlacementStats(advertiserId: string) {
             where: { ad: { adGroup: { campaign: { advertiser_id: advId } } }, is_valid: 1 }
           }
         }
+      },
+      clicks: {
+        where: { 
+          ad: { adGroup: { campaign: { advertiser_id: advId } } },
+          is_valid: 1 
+        },
+        select: {
+          cost: true,
+          conversions: {
+            select: {
+              revenue: true
+            }
+          }
+        }
       }
     }
   });
 
-  return publishers.map(p => ({
-    id: p.id,
-    name: p.name,
-    domain: p.domain,
-    impressions: p._count.impressions,
-    clicks: p._count.clicks
-  })).sort((a, b) => b.impressions - a.impressions);
+  return publishers.map(p => {
+    const totalCost = p.clicks.reduce((acc, curr) => acc + curr.cost, 0);
+    const conversions = p.clicks.flatMap(c => c.conversions);
+    const cvCount = conversions.length;
+    const cvRevenue = conversions.reduce((acc, curr) => acc + curr.revenue, 0);
+
+    return {
+      id: p.id,
+      name: p.name,
+      domain: p.domain,
+      impressions: p._count.impressions,
+      clicks: p._count.clicks,
+      cost: totalCost,
+      conversions: cvCount,
+      revenue: cvRevenue
+    };
+  }).sort((a, b) => b.impressions - a.impressions);
 }


### PR DESCRIPTION
### Objective
Expand the newly implemented conversion tracking data into all advertiser-facing reports to provide granular performance insights (CV, CVR, CPA, Revenue).

### Changes
- **Data Layer**: 
  - Updated `AdvertiserDashboard` to fetch aggregate CV data for Ads, Campaigns, and Ad Groups.
  - Updated `getPlacementStats` service to include conversion metrics per publisher.
- **UI Components**:
  - `AdsPerformanceTable`: Added CV, CVR, CPA, and Revenue columns for creative-level analysis.
  - `PlacementReportTable`: Added conversion metrics to identify high-performing domains.
  - `CampaignsTable` & `AdGroupsTable`: Added summary CV/Revenue data.

This completes the initial integration of conversion data into the analytics dashboard.