### PR TITLE
feat: implement accurate impression tracking with tracking pixel (fixes #93)

### DIFF
--- a/src/app/api/click/route.test.ts
+++ b/src/app/api/click/route.test.ts
@@ -25,7 +25,7 @@ describe('GET /api/click', () => {
   });
 
   it('should record a click with ad_unit_id and redirect with click_id', async () => {
-    const req = new NextRequest('http://localhost/api/click?ad_id=1&publisher_id=1&ad_unit_id=1', {
+    const req = new NextRequest('http://localhost/api/click?ad_id=1&ad_unit_id=1', {
       headers: {
         'user-agent': 'Mozilla/5.0...',
         'x-forwarded-for': '1.2.3.4'
@@ -50,7 +50,7 @@ describe('GET /api/click', () => {
   });
 
   it('should return 404 if ad is not found', async () => {
-    const req = new NextRequest('http://localhost/api/click?ad_id=999');
+    const req = new NextRequest('http://localhost/api/click?ad_id=999&ad_unit_id=1');
     const res = await GET(req);
     expect(res.status).toBe(404);
   });

--- a/src/app/api/click/route.ts
+++ b/src/app/api/click/route.ts
@@ -4,26 +4,30 @@ import prisma from "@/lib/db";
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const adIdParam = searchParams.get("ad_id");
-  const publisherIdParam = searchParams.get("publisher_id");
   const adUnitIdParam = searchParams.get("ad_unit_id");
   
-  if (!adIdParam) {
-    return new NextResponse("ad_id is required", { status: 400 });
+  if (!adIdParam || !adUnitIdParam) {
+    return new NextResponse("ad_id and ad_unit_id are required", { status: 400 });
   }
 
   const adId = parseInt(adIdParam, 10);
-  const publisherId = publisherIdParam ? parseInt(publisherIdParam, 10) : 0;
-  const adUnitId = adUnitIdParam ? parseInt(adUnitIdParam, 10) : null;
+  const adUnitId = parseInt(adUnitIdParam, 10);
   const ua = req.headers.get("user-agent") || "";
   const ip = req.headers.get("x-forwarded-for") || "unknown";
 
   try {
-    const ad = await prisma.ad.findUnique({
-      where: { id: adId },
-      include: { adGroup: { include: { campaign: true } } }
-    });
+    const [ad, adUnit] = await Promise.all([
+      prisma.ad.findUnique({
+        where: { id: adId },
+        include: { adGroup: { include: { campaign: true } } }
+      }),
+      prisma.adUnit.findUnique({
+        where: { id: adUnitId },
+        include: { app: true }
+      })
+    ]);
 
-    if (ad) {
+    if (ad && adUnit) {
       const clickId = crypto.randomUUID();
 
       // 未処理のクリックとしてログ挿入
@@ -31,7 +35,7 @@ export async function GET(req: NextRequest) {
         data: {
           click_id: clickId,
           ad_id: adId,
-          publisher_id: publisherId,
+          publisher_id: adUnit.app.publisher_id,
           ad_unit_id: adUnitId,
           campaign_id: ad.adGroup.campaign.id,
           cost: ad.adGroup.max_bid,

--- a/src/app/api/impression/route.ts
+++ b/src/app/api/impression/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/db";
+
+// 1x1 Transparent GIF pixel
+const PIXEL = Buffer.from(
+  "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+  "base64"
+);
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const adId = searchParams.get("ad_id");
+  const adUnitId = searchParams.get("ad_unit_id");
+
+  if (!adId || !adUnitId) {
+    return new NextResponse("Missing parameters", { status: 400 });
+  }
+
+  const ua = req.headers.get("user-agent") || "";
+  const ip = req.headers.get("x-forwarded-for") || "unknown";
+
+  try {
+    // ad_unit_id から publisher_id を特定する
+    const adUnit = await prisma.adUnit.findUnique({
+      where: { id: parseInt(adUnitId, 10) },
+      include: { app: true }
+    });
+
+    if (adUnit) {
+      // Record the actual impression
+      await prisma.impression.create({
+        data: {
+          ad_id: parseInt(adId, 10),
+          publisher_id: adUnit.app.publisher_id,
+          ad_unit_id: adUnit.id,
+          user_agent: ua,
+          ip_address: ip,
+        }
+      });
+    }
+  } catch (error) {
+    console.error("Impression tracking error:", error);
+    // Even if DB fails, return the pixel so the browser doesn't retry or show broken image
+  }
+
+  return new NextResponse(PIXEL, {
+    headers: {
+      "Content-Type": "image/gif",
+      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+      "Pragma": "no-cache",
+      "Expires": "0",
+      "Surrogate-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/serve/route.test.ts
+++ b/src/app/api/serve/route.test.ts
@@ -31,26 +31,41 @@ describe('GET /api/serve', () => {
     expect(res.status).toBe(404);
   });
 
-  it('should serve an ad and record an impression with ad_unit_id', async () => {
+  it('should return ad HTML with a tracking pixel but NOT record impression immediately', async () => {
     const req = new NextRequest('http://localhost/api/serve?ad_unit_id=1', {
       headers: { 'user-agent': 'Mozilla/5.0', 'x-forwarded-for': '1.2.3.4' }
     });
     
     const res = await GET(req);
     expect(res.status).toBe(200);
-    expect(res.headers.get('Content-Type')).toBe('text/html');
     
     const html = await res.text();
     expect(html).toContain('Ad 1');
-    expect(html).toContain('http://img.com');
-    // Verify click URL contains ad_unit_id
+    // Verify tracking pixel is present
+    expect(html).toContain('/api/impression?ad_id=1');
+    expect(html).not.toContain('publisher_id='); // Should be hidden
     expect(html).toContain('ad_unit_id=1');
+
+    // Verify impression is NOT recorded yet
+    const impCount = await prisma.impression.count();
+    expect(impCount).toBe(0);
+  });
+
+  it('should record an impression when the tracking pixel is requested', async () => {
+    const { GET: pixelGET } = await import('../impression/route');
+    const pixelReq = new NextRequest('http://localhost/api/impression?ad_id=1&ad_unit_id=1', {
+      headers: { 'user-agent': 'Mozilla/5.0', 'x-forwarded-for': '5.6.7.8' }
+    });
+
+    const res = await pixelGET(pixelReq);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/gif');
 
     // Verify impression record
     const imp = await prisma.impression.findFirst({ where: { ad_id: 1, ad_unit_id: 1 } });
     expect(imp).toBeDefined();
     expect(imp?.publisher_id).toBe(1);
-    expect(imp?.ip_address).toBe('1.2.3.4');
+    expect(imp?.ip_address).toBe('5.6.7.8');
   });
 
   it('should return 204 if no matching ad is found', async () => {

--- a/src/app/api/serve/route.tsx
+++ b/src/app/api/serve/route.tsx
@@ -114,17 +114,6 @@ export async function GET(req: NextRequest) {
     return new NextResponse(null, { status: 204 });
   }
 
-  // インプレッションを記録
-  await prisma.impression.create({
-    data: {
-      ad_id: ad.id,
-      publisher_id: publisherId,
-      ad_unit_id: adUnitId,
-      user_agent: ua,
-      ip_address: ip,
-    }
-  });
-
   // Reactコンポーネントを使用して安全なHTMLを生成 (自動エスケープによるXSS対策)
   const { renderToStaticMarkup } = await import('react-dom/server');
   const AdCreative = (await import('@/components/AdCreative')).default;
@@ -132,12 +121,26 @@ export async function GET(req: NextRequest) {
   // Safe URL building
   const clickUrlObj = new URL(`${new URL(req.url).origin}/api/click`);
   clickUrlObj.searchParams.set("ad_id", ad.id.toString());
-  clickUrlObj.searchParams.set("publisher_id", publisherId.toString());
   clickUrlObj.searchParams.set("ad_unit_id", adUnitId.toString());
   const clickUrl = clickUrlObj.toString();
 
+  // Tracking Pixel URL
+  const pixelUrlObj = new URL(`${new URL(req.url).origin}/api/impression`);
+  pixelUrlObj.searchParams.set("ad_id", ad.id.toString());
+  pixelUrlObj.searchParams.set("ad_unit_id", adUnitId.toString());
+  const pixelUrl = pixelUrlObj.toString();
+
   const adHtml = renderToStaticMarkup(
-    <AdCreative ad={ad} clickUrl={clickUrl} />
+    <>
+      <AdCreative ad={ad} clickUrl={clickUrl} />
+      <img 
+        src={pixelUrl} 
+        width="1" 
+        height="1" 
+        style={{ display: 'none' }} 
+        alt="" 
+      />
+    </>
   );
 
   return new NextResponse(`<!DOCTYPE html><html><body style="margin:0;">${adHtml}</body></html>`, {


### PR DESCRIPTION
### Objective
Improve impression counting accuracy by using a tracking pixel (beacon) and enhance privacy by hiding `publisher_id` from client-side parameters.

### Changes
- **New API**: Created `/api/impression` to handle tracking pixel requests and record actual impressions.
- **Delivery Update**: Modified `/api/serve` to inject an invisible `<img>` tag instead of recording impressions at request-time.
- **Privacy**: Removed `publisher_id` from all client-side URLs (`serve`, `click`, `impression`). The system now infers the publisher from the `ad_unit_id`.
- **API Update**: Updated `/api/click` to require `ad_unit_id` and automatically link to the correct publisher.
- **Testing**: Updated all integration tests to support the new pixel-based flow and hidden parameters.

Fixes #93