### PR TITLE
feat: implement detailed Ad Unit performance reporting with eCPM for publishers (fixes #99)

### DIFF
--- a/src/app/publisher/[id]/page.tsx
+++ b/src/app/publisher/[id]/page.tsx
@@ -1,8 +1,9 @@
 import prisma from "@/lib/db";
-import { getDailyStats } from "@/services/stats";
+import { getDailyStats, getAdUnitStats } from "@/services/stats";
 import Link from "next/link";
 import { notFound, forbidden } from "next/navigation";
 import StatsChart from "@/components/StatsChart";
+import AdUnitPerformanceTable from "@/components/AdUnitPerformanceTable";
 import { requestPayout, updatePublisherProfile, createApp, deleteApp, createAdUnit, deleteAdUnit } from "./actions";
 import { auth } from "@/auth";
 
@@ -37,8 +38,8 @@ export default async function PublisherDashboard({ params }: PageProps) {
 
   const impressionsCount = await prisma.impression.count({ where: { publisher_id: id } });
   const clicksCount = await prisma.click.count({ where: { publisher_id: id, is_valid: 1 } });
-  const payouts = await prisma.payout.findMany({ where: { publisher_id: id }, orderBy: { created_at: 'desc' } });
   const dailyStats = await getDailyStats({ publisherId: id.toString() }) as any[];
+  const adUnitStats = await getAdUnitStats(id.toString());
 
   return (
     <div className="min-h-screen bg-slate-50 p-8">
@@ -75,6 +76,9 @@ export default async function PublisherDashboard({ params }: PageProps) {
           <h2 className="text-xl font-black mb-6 text-slate-800 tracking-tight">Performance History</h2>
           <StatsChart data={dailyStats} />
         </section>
+
+        {/* Ad Unit Analysis Report */}
+        <AdUnitPerformanceTable stats={adUnitStats} />
 
         {/* App & Ad Unit Management */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/src/components/AdUnitPerformanceTable.tsx
+++ b/src/components/AdUnitPerformanceTable.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMemo } from "react";
+import { createColumnHelper, ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "./DataTable";
+
+interface AdUnitStat {
+  id: number;
+  name: string;
+  app_name: string;
+  ad_type: string;
+  width: number | null;
+  height: number | null;
+  impressions: number;
+  clicks: number;
+  revenue: number;
+}
+
+interface AdUnitPerformanceTableProps {
+  stats: AdUnitStat[];
+}
+
+export default function AdUnitPerformanceTable({ stats }: AdUnitPerformanceTableProps) {
+  const columnHelper = createColumnHelper<AdUnitStat>();
+
+  const columns = useMemo(() => [
+    columnHelper.accessor("name", {
+      id: "ad_unit",
+      header: "Ad Unit / App",
+      cell: (info) => (
+        <div>
+          <div className="font-bold text-gray-900 leading-tight">{info.getValue()}</div>
+          <div className="text-[10px] text-gray-400 uppercase font-medium">{info.row.original.app_name}</div>
+        </div>
+      ),
+    }),
+    columnHelper.accessor("ad_type", {
+      header: "Format",
+      cell: (info) => (
+        <div>
+          <span className="px-2 py-0.5 bg-slate-100 text-slate-600 rounded text-[10px] font-bold uppercase">
+            {info.getValue()}
+          </span>
+          {info.row.original.width && (
+            <div className="text-[10px] text-gray-400 mt-1 font-mono">
+              {info.row.original.width}x{info.row.original.height}
+            </div>
+          )}
+        </div>
+      ),
+    }),
+    columnHelper.accessor("impressions", {
+      header: "Imps",
+      cell: (info) => <span className="font-mono font-bold text-slate-700">{info.getValue().toLocaleString()}</span>,
+    }),
+    columnHelper.accessor("clicks", {
+      header: "Clicks",
+      cell: (info) => <span className="font-mono font-bold text-slate-700">{info.getValue().toLocaleString()}</span>,
+    }),
+    columnHelper.display({
+      id: "ctr",
+      header: "CTR",
+      cell: (info) => {
+        const { impressions, clicks } = info.row.original;
+        const ctr = impressions > 0 ? (clicks / impressions) * 100 : 0;
+        return <span className="text-gray-600 font-bold">{ctr.toFixed(2)}%</span>;
+      },
+      sortingFn: (rowA, rowB) => {
+        const ctrA = rowA.original.impressions > 0 ? rowA.original.clicks / rowA.original.impressions : 0;
+        const ctrB = rowB.original.impressions > 0 ? rowB.original.clicks / rowB.original.impressions : 0;
+        return ctrA - ctrB;
+      }
+    }),
+    columnHelper.accessor("revenue", {
+      header: "Est. Revenue",
+      cell: (info) => <span className="font-mono font-bold text-emerald-700">¥{info.getValue().toLocaleString()}</span>,
+    }),
+    columnHelper.display({
+      id: "ecpm",
+      header: "eCPM",
+      cell: (info) => {
+        const { impressions, revenue } = info.row.original;
+        const ecpm = impressions > 0 ? (revenue / impressions) * 1000 : 0;
+        return (
+          <div className="text-right">
+            <span className="font-mono font-black text-blue-700">¥{Math.floor(ecpm).toLocaleString()}</span>
+            <div className="text-[8px] text-blue-400 font-bold uppercase leading-none">Efficiency</div>
+          </div>
+        );
+      },
+      sortingFn: (rowA, rowB) => {
+        const ecpmA = rowA.original.impressions > 0 ? rowA.original.revenue / rowA.original.impressions : 0;
+        const ecpmB = rowB.original.impressions > 0 ? rowB.original.revenue / rowB.original.impressions : 0;
+        return ecpmA - ecpmB;
+      }
+    }),
+  ], [columnHelper]);
+
+  return (
+    <section className="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden mb-12">
+      <div className="p-6 border-b border-slate-100 bg-slate-50/50 flex justify-between items-end">
+        <div>
+          <h2 className="text-xl font-black text-slate-800 tracking-tight">Ad Unit Performance Analysis</h2>
+          <p className="text-sm text-slate-500 mt-1">広告枠ごとの収益効率を分析します。eCPMが高い枠を優先的に配置することをお勧めします。</p>
+        </div>
+        <div className="bg-blue-600 text-white px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest shadow-lg shadow-blue-200">
+          Professional Report
+        </div>
+      </div>
+
+      <DataTable 
+        columns={columns as ColumnDef<AdUnitStat, any>[]} 
+        data={stats}
+        defaultVisibility={{
+          ad_type: true,
+          ctr: true,
+        }}
+      />
+    </section>
+  );
+}

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -129,18 +129,25 @@ async function seed() {
     date.setDate(date.getDate() - (6 - i));
     date.setUTCHours(12, 0, 0, 0);
 
-    // Pub 1 (Unit 1): Increasing Trend
+    // Pub 1 (Unit 1): Increasing Trend - High Efficiency
     const pub1Count = (i + 1) * 100;
     await prisma.impression.createMany({ data: Array.from({ length: pub1Count }).map(() => ({ ad_id: 1, publisher_id: 1, ad_unit_id: 1, created_at: date })) });
-    for (let j = 0; j < Math.floor(pub1Count * 0.1); j++) {
-      await prisma.click.create({ data: { ad_id: 1, publisher_id: 1, ad_unit_id: 1, campaign_id: 1, cost: 100, publisher_earnings: 70, is_valid: 1, processed: 1, created_at: date } });
+    for (let j = 0; j < Math.floor(pub1Count * 0.15); j++) { // 15% CTR!
+      await prisma.click.create({ data: { ad_id: 1, publisher_id: 1, ad_unit_id: 1, campaign_id: 1, cost: 150, publisher_earnings: 105, is_valid: 1, processed: 1, created_at: date } });
     }
 
-    // Pub 2 (Unit 3): Decreasing Trend
+    // Pub 1 (Unit 2): Bottom Leaderboard - Lower CTR
+    const pub1Unit2Count = 200;
+    await prisma.impression.createMany({ data: Array.from({ length: pub1Unit2Count }).map(() => ({ ad_id: 1, publisher_id: 1, ad_unit_id: 2, created_at: date })) });
+    for (let j = 0; j < Math.floor(pub1Unit2Count * 0.02); j++) { // 2% CTR
+      await prisma.click.create({ data: { ad_id: 1, publisher_id: 1, ad_unit_id: 2, campaign_id: 1, cost: 100, publisher_earnings: 70, is_valid: 1, processed: 1, created_at: date } });
+    }
+
+    // Pub 2 (Unit 3): Article Mid - Average
     const pub2Count = (7 - i) * 100;
     await prisma.impression.createMany({ data: Array.from({ length: pub2Count }).map(() => ({ ad_id: 1, publisher_id: 2, ad_unit_id: 3, created_at: date })) });
-    for (let j = 0; j < Math.floor(pub2Count * 0.1); j++) {
-      await prisma.click.create({ data: { ad_id: 1, publisher_id: 2, ad_unit_id: 3, campaign_id: 1, cost: 100, publisher_earnings: 80, is_valid: 1, processed: 1, created_at: date } });
+    for (let j = 0; j < Math.floor(pub2Count * 0.05); j++) { // 5% CTR
+      await prisma.click.create({ data: { ad_id: 1, publisher_id: 2, ad_unit_id: 3, campaign_id: 1, cost: 120, publisher_earnings: 96, is_valid: 1, processed: 1, created_at: date } });
     }
   }
 

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -134,3 +134,45 @@ export async function getPlacementStats(advertiserId: string) {
     };
   }).sort((a, b) => b.impressions - a.impressions);
 }
+
+export async function getAdUnitStats(publisherId: string) {
+  const pubId = parseInt(publisherId, 10);
+
+  const adUnits = await prisma.adUnit.findMany({
+    where: { app: { publisher_id: pubId } },
+    include: {
+      app: {
+        select: { name: true }
+      },
+      _count: {
+        select: {
+          impressions: true,
+          clicks: {
+            where: { is_valid: 1 }
+          }
+        }
+      },
+      clicks: {
+        where: { is_valid: 1 },
+        select: {
+          publisher_earnings: true
+        }
+      }
+    }
+  });
+
+  return adUnits.map(unit => {
+    const revenue = unit.clicks.reduce((acc, curr) => acc + curr.publisher_earnings, 0);
+    return {
+      id: unit.id,
+      name: unit.name,
+      app_name: unit.app.name,
+      ad_type: unit.ad_type,
+      width: unit.width,
+      height: unit.height,
+      impressions: unit._count.impressions,
+      clicks: unit._count.clicks,
+      revenue: revenue
+    };
+  }).sort((a, b) => b.revenue - a.revenue); // 収益順にソートして返すよ！💰
+}


### PR DESCRIPTION
### Objective
Empower publishers with granular performance data per Ad Unit, including professional metrics like eCPM.

### Changes
- **Service Layer**: Added `getAdUnitStats` to aggregate impressions, clicks, and estimated revenue per unit.
- **UI Component**: Created `AdUnitPerformanceTable` using TanStack Table for sorting and column management.
- **Metrics**: Calculated **eCPM** (Effective Cost Per Mille) and **Estimated Revenue** (Publisher's share) to show placement efficiency.
- **Seeding**: Enhanced mock data to provide varied performance across different ad units for better demonstration.

Fixes #99