### PR TITLE
feat: add too fast click detection for IVT 🛡️🕵️‍♀️

### DIFF
--- a/prisma/migrations/20260321024310_add_imp_id_to_impression_and_click/migration.sql
+++ b/prisma/migrations/20260321024310_add_imp_id_to_impression_and_click/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[imp_id]` on the table `impressions` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "clicks" ADD COLUMN "imp_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "impressions" ADD COLUMN "imp_id" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "impressions_imp_id_key" ON "impressions"("imp_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,12 +160,12 @@ model Ad {
 
   @@map("ads")
 }
-
 model Impression {
   id           Int       @id @default(autoincrement())
   ad_id        Int
   publisher_id Int
   ad_unit_id   Int?
+  imp_id       String?   @unique // Unique ID per ad serving
   user_agent   String?
   ip_address   String?
   created_at   DateTime  @default(now())
@@ -179,6 +179,7 @@ model Impression {
 model Click {
   id                 Int       @id @default(autoincrement())
   click_id           String?   @unique
+  imp_id             String?   // Linked to an impression
   ad_id              Int
   publisher_id       Int
   ad_unit_id         Int?

--- a/src/app/api/click/route.ts
+++ b/src/app/api/click/route.ts
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const adIdParam = searchParams.get("ad_id");
   const adUnitIdParam = searchParams.get("ad_unit_id");
+  const impId = searchParams.get("imp_id"); // Get imp_id
   
   if (!adIdParam || !adUnitIdParam) {
     return new NextResponse("ad_id and ad_unit_id are required", { status: 400 });
@@ -34,6 +35,7 @@ export async function GET(req: NextRequest) {
       await prisma.click.create({
         data: {
           click_id: clickId,
+          imp_id: impId, // Save imp_id
           ad_id: adId,
           publisher_id: adUnit.app.publisher_id,
           ad_unit_id: adUnitId,

--- a/src/app/api/impression/route.ts
+++ b/src/app/api/impression/route.ts
@@ -11,6 +11,7 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const adId = searchParams.get("ad_id");
   const adUnitId = searchParams.get("ad_unit_id");
+  const impId = searchParams.get("imp_id"); // Get imp_id
 
   if (!adId || !adUnitId) {
     return new NextResponse("Missing parameters", { status: 400 });
@@ -33,6 +34,7 @@ export async function GET(req: NextRequest) {
           ad_id: parseInt(adId, 10),
           publisher_id: adUnit.app.publisher_id,
           ad_unit_id: adUnit.id,
+          imp_id: impId, // Save imp_id
           user_agent: ua,
           ip_address: ip,
         }

--- a/src/app/api/serve/route.tsx
+++ b/src/app/api/serve/route.tsx
@@ -127,6 +127,9 @@ export async function GET(req: NextRequest) {
     return new NextResponse(null, { status: 204 });
   }
 
+  // Impression ID の発行 (不正クリック判定用)
+  const impId = crypto.randomUUID();
+
   // Reactコンポーネントを使用して安全なHTMLを生成 (自動エスケープによるXSS対策)
   const { renderToStaticMarkup } = await import('react-dom/server');
   const AdCreative = (await import('@/components/AdCreative')).default;
@@ -135,12 +138,14 @@ export async function GET(req: NextRequest) {
   const clickUrlObj = new URL(`${new URL(req.url).origin}/api/click`);
   clickUrlObj.searchParams.set("ad_id", ad.id.toString());
   clickUrlObj.searchParams.set("ad_unit_id", adUnitId.toString());
+  clickUrlObj.searchParams.set("imp_id", impId); // Add imp_id
   const clickUrl = clickUrlObj.toString();
 
   // Tracking Pixel URL
   const pixelUrlObj = new URL(`${new URL(req.url).origin}/api/impression`);
   pixelUrlObj.searchParams.set("ad_id", ad.id.toString());
   pixelUrlObj.searchParams.set("ad_unit_id", adUnitId.toString());
+  pixelUrlObj.searchParams.set("imp_id", impId); // Add imp_id
   const pixelUrl = pixelUrlObj.toString();
 
   const adHtml = renderToStaticMarkup(

--- a/src/services/billing.test.ts
+++ b/src/services/billing.test.ts
@@ -4,39 +4,62 @@ import { runBillingWorker } from './billing';
 import { clearDatabase } from '../lib/test-utils';
 
 describe('Billing Service', () => {
+  let adv1: any;
+  let pub1: any;
+  let camp1: any;
+  let group1: any;
+  let ad1: any;
+
   beforeEach(async () => {
     await clearDatabase();
 
     // Setup initial data
-    await prisma.advertiser.create({
-      data: { id: 1, name: 'Adv 1', balance: 1000 }
+    adv1 = await prisma.advertiser.create({
+      data: { name: 'Adv 1', balance: 1000 }
     });
-    await prisma.publisher.create({
-      data: { id: 1, name: 'Pub 1', domain: 'p1.com', rev_share: 0.7 }
+    pub1 = await prisma.publisher.create({
+      data: { name: 'Pub 1', rev_share: 0.7 }
     });
-    await prisma.campaign.create({
-      data: { id: 1, advertiser_id: 1, name: 'Camp 1' }
+    camp1 = await prisma.campaign.create({
+      data: { advertiser_id: adv1.id, name: 'Camp 1' }
     });
-    await prisma.adGroup.create({
-      data: { id: 1, campaign_id: 1, name: 'Group 1', max_bid: 100 }
+    group1 = await prisma.adGroup.create({
+      data: { campaign_id: camp1.id, name: 'Group 1', max_bid: 100 }
     });
-    await prisma.ad.create({
-      data: { id: 1, ad_group_id: 1, title: 'Ad 1', target_url: 'http://t.com', status: 'approved' }
+    ad1 = await prisma.ad.create({
+      data: { ad_group_id: group1.id, title: 'Ad 1', target_url: 'http://t.com', status: 'approved' }
     });
   });
 
   it('should process a valid pending click and update balances', async () => {
+    const impId = 'imp_valid';
+    // Create an impression first (required for isTooFastClick)
+    await prisma.impression.create({
+      data: {
+        ad_id: ad1.id,
+        publisher_id: pub1.id,
+        imp_id: impId,
+        created_at: new Date(Date.now() - 5000) // 5 seconds ago
+      }
+    });
+
     await prisma.click.create({
-      data: { ad_id: 1, publisher_id: 1, ip_address: '1.1.1.1', processed: 0 }
+      data: { 
+        ad_id: ad1.id, 
+        publisher_id: pub1.id, 
+        imp_id: impId,
+        ip_address: '1.1.1.1', 
+        processed: 0 
+      }
     });
 
     const processed = await runBillingWorker();
     expect(processed).toBe(1);
 
-    const adv = await prisma.advertiser.findUnique({ where: { id: 1 } });
+    const adv = await prisma.advertiser.findUnique({ where: { id: adv1.id } });
     expect(adv?.balance).toBe(900); // 1000 - 100
 
-    const pub = await prisma.publisher.findUnique({ where: { id: 1 } });
+    const pub = await prisma.publisher.findUnique({ where: { id: pub1.id } });
     expect(pub?.balance).toBe(70); // 100 * 0.7
     expect(pub?.total_earnings).toBe(70);
 
@@ -46,19 +69,35 @@ describe('Billing Service', () => {
   });
 
   it('should invalidate click if advertiser has insufficient balance', async () => {
+    const impId = 'imp_nobalance';
+    await prisma.impression.create({
+      data: {
+        ad_id: ad1.id,
+        publisher_id: pub1.id,
+        imp_id: impId,
+        created_at: new Date(Date.now() - 5000)
+      }
+    });
+
     await prisma.advertiser.update({
-      where: { id: 1 },
+      where: { id: adv1.id },
       data: { balance: 50 }
     });
 
     await prisma.click.create({
-      data: { ad_id: 1, publisher_id: 1, ip_address: '1.1.1.1', processed: 0 }
+      data: { 
+        ad_id: ad1.id, 
+        publisher_id: pub1.id, 
+        imp_id: impId,
+        ip_address: '1.1.1.1', 
+        processed: 0 
+      }
     });
 
     const processed = await runBillingWorker();
     expect(processed).toBe(1);
 
-    const adv = await prisma.advertiser.findUnique({ where: { id: 1 } });
+    const adv = await prisma.advertiser.findUnique({ where: { id: adv1.id } });
     expect(adv?.balance).toBe(50); // No change
 
     const click = await prisma.click.findFirst();
@@ -67,14 +106,30 @@ describe('Billing Service', () => {
   });
 
   it('should invalidate click if daily budget is exceeded', async () => {
+    const impId = 'imp_budget';
+    await prisma.impression.create({
+      data: {
+        ad_id: ad1.id,
+        publisher_id: pub1.id,
+        imp_id: impId,
+        created_at: new Date(Date.now() - 5000)
+      }
+    });
+
     // Set daily budget very low
     await prisma.campaign.update({
-      where: { id: 1 },
+      where: { id: camp1.id },
       data: { daily_budget: 50 } // Max bid is 100
     });
 
     await prisma.click.create({
-      data: { ad_id: 1, publisher_id: 1, ip_address: '1.1.1.1', processed: 0 }
+      data: { 
+        ad_id: ad1.id, 
+        publisher_id: pub1.id, 
+        imp_id: impId,
+        ip_address: '1.1.1.1', 
+        processed: 0 
+      }
     });
 
     const processed = await runBillingWorker();
@@ -83,5 +138,34 @@ describe('Billing Service', () => {
     const click = await prisma.click.findFirst();
     expect(click?.is_valid).toBe(0);
     expect(click?.invalid_reason).toBe('Daily budget exceeded');
+  });
+
+  it('should invalidate click if it occurred too fast after impression', async () => {
+    const impId = 'imp_fast';
+    await prisma.impression.create({
+      data: {
+        ad_id: ad1.id,
+        publisher_id: pub1.id,
+        imp_id: impId,
+        created_at: new Date() // Just now
+      }
+    });
+
+    await prisma.click.create({
+      data: { 
+        ad_id: ad1.id, 
+        publisher_id: pub1.id, 
+        imp_id: impId,
+        ip_address: '1.1.1.1', 
+        processed: 0 
+      }
+    });
+
+    const processed = await runBillingWorker();
+    expect(processed).toBe(1);
+
+    const click = await prisma.click.findFirst();
+    expect(click?.is_valid).toBe(0);
+    expect(click?.invalid_reason).toBe('Too fast click');
   });
 });

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -1,5 +1,5 @@
 import prisma from '../lib/db';
-import { isBotUserAgent, isRateLimited, isDuplicate } from './ivt';
+import { isBotUserAgent, isRateLimited, isDuplicate, isTooFastClick } from './ivt';
 
 export async function runBillingWorker() {
   try {
@@ -37,6 +37,15 @@ export async function runBillingWorker() {
           await tx.click.update({
             where: { id: click.id },
             data: { is_valid: 0, processed: 1, invalid_reason: 'Duplicate click (10s)' }
+          });
+          return;
+        }
+
+        // 4. Too Fast Click Check (Impression to Click time)
+        if (await isTooFastClick(prisma, click)) {
+          await tx.click.update({
+            where: { id: click.id },
+            data: { is_valid: 0, processed: 1, invalid_reason: 'Too fast click' }
           });
           return;
         }

--- a/src/services/ivt.test.ts
+++ b/src/services/ivt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import prisma from '../lib/db';
-import { isBotUserAgent, isRateLimited, isDuplicate } from './ivt';
+import { isBotUserAgent, isRateLimited, isDuplicate, isTooFastClick } from './ivt';
 import { clearDatabase } from '../lib/test-utils';
 
 describe('IVT Service (Invalid Traffic Detection)', () => {
@@ -23,17 +23,23 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
   });
 
   describe('Database checks', () => {
+    let advertiser: any;
+    let publisher: any;
+    let campaign: any;
+    let adGroup: any;
+    let ad1: any;
+    let ad2: any;
+
     beforeEach(async () => {
       await clearDatabase();
       
       // Setup some basic dependent data
-      await prisma.advertiser.create({ data: { id: 1, name: 'Adv' } });
-      await prisma.publisher.create({ data: { id: 1, name: 'Pub', domain: 'example.com' } });
-      await prisma.campaign.create({ data: { id: 1, advertiser_id: 1, name: 'Camp' } });
-      await prisma.adGroup.create({ data: { id: 1, campaign_id: 1, name: 'Group' } });
-      await prisma.ad.create({ data: { id: 1, ad_group_id: 1, title: 'Ad 1', target_url: 'http://example.com' } });
-      // Create ad 2 for duplicate test
-      await prisma.ad.create({ data: { id: 2, ad_group_id: 1, title: 'Ad 2', target_url: 'http://example2.com' } });
+      advertiser = await prisma.advertiser.create({ data: { name: 'Adv' } });
+      publisher = await prisma.publisher.create({ data: { name: 'Pub' } });
+      campaign = await prisma.campaign.create({ data: { advertiser_id: advertiser.id, name: 'Camp' } });
+      adGroup = await prisma.adGroup.create({ data: { campaign_id: campaign.id, name: 'Group' } });
+      ad1 = await prisma.ad.create({ data: { ad_group_id: adGroup.id, title: 'Ad 1', target_url: 'http://example.com' } });
+      ad2 = await prisma.ad.create({ data: { ad_group_id: adGroup.id, title: 'Ad 2', target_url: 'http://example2.com' } });
     });
 
     describe('isDuplicate', () => {
@@ -41,8 +47,8 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
         // Insert an initial valid click
         await prisma.click.create({
           data: {
-            ad_id: 1,
-            publisher_id: 1,
+            ad_id: ad1.id,
+            publisher_id: publisher.id,
             ip_address: '192.168.1.1',
             is_valid: 1,
             created_at: new Date('2026-03-12T10:00:00Z')
@@ -50,30 +56,30 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
         });
 
         // Check a new click occurring 5 seconds later
-        const isDup = await isDuplicate(prisma, 1, '192.168.1.1', 999, new Date('2026-03-12T10:00:05Z'));
+        const isDup = await isDuplicate(prisma, ad1.id, '192.168.1.1', 9999, new Date('2026-03-12T10:00:05Z'));
         expect(isDup).toBe(true);
       });
 
       it('should not detect duplicate if more than 10 seconds have passed', async () => {
         await prisma.click.create({
           data: {
-            ad_id: 1,
-            publisher_id: 1,
+            ad_id: ad1.id,
+            publisher_id: publisher.id,
             ip_address: '192.168.1.1',
             is_valid: 1,
             created_at: new Date('2026-03-12T10:00:00Z')
           }
         });
 
-        const isDup = await isDuplicate(prisma, 1, '192.168.1.1', 999, new Date('2026-03-12T10:00:11Z'));
+        const isDup = await isDuplicate(prisma, ad1.id, '192.168.1.1', 9999, new Date('2026-03-12T10:00:11Z'));
         expect(isDup).toBe(false);
       });
 
       it('should not detect duplicate for different ad', async () => {
         await prisma.click.create({
           data: {
-            ad_id: 1,
-            publisher_id: 1,
+            ad_id: ad1.id,
+            publisher_id: publisher.id,
             ip_address: '192.168.1.1',
             is_valid: 1,
             created_at: new Date('2026-03-12T10:00:00Z')
@@ -81,7 +87,7 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
         });
 
         // Check for ad_id 2
-        const isDup = await isDuplicate(prisma, 2, '192.168.1.1', 999, new Date('2026-03-12T10:00:05Z'));
+        const isDup = await isDuplicate(prisma, ad2.id, '192.168.1.1', 9999, new Date('2026-03-12T10:00:05Z'));
         expect(isDup).toBe(false);
       });
     });
@@ -91,8 +97,8 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
         for (let i = 0; i < 50; i++) {
           await prisma.click.create({
             data: {
-              ad_id: 1,
-              publisher_id: 1,
+              ad_id: ad1.id,
+              publisher_id: publisher.id,
               ip_address: '10.0.0.1',
               is_valid: 1,
               created_at: new Date('2026-03-12T10:30:00Z')
@@ -100,7 +106,7 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
           });
         }
 
-        const isLimited = await isRateLimited(prisma, '10.0.0.1', 999, new Date('2026-03-12T10:59:59Z'));
+        const isLimited = await isRateLimited(prisma, '10.0.0.1', 9999, new Date('2026-03-12T10:59:59Z'));
         expect(isLimited).toBe(true);
       });
 
@@ -108,8 +114,8 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
         for (let i = 0; i < 49; i++) {
           await prisma.click.create({
             data: {
-              ad_id: 1,
-              publisher_id: 1,
+              ad_id: ad1.id,
+              publisher_id: publisher.id,
               ip_address: '10.0.0.1',
               is_valid: 1,
               created_at: new Date('2026-03-12T10:30:00Z')
@@ -117,7 +123,7 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
           });
         }
 
-        const isLimited = await isRateLimited(prisma, '10.0.0.1', 999, new Date('2026-03-12T10:59:59Z'));
+        const isLimited = await isRateLimited(prisma, '10.0.0.1', 9999, new Date('2026-03-12T10:59:59Z'));
         expect(isLimited).toBe(false);
       });
       
@@ -125,8 +131,8 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
         for (let i = 0; i < 50; i++) {
           await prisma.click.create({
             data: {
-              ad_id: 1,
-              publisher_id: 1,
+              ad_id: ad1.id,
+              publisher_id: publisher.id,
               ip_address: '10.0.0.1',
               is_valid: 1,
               created_at: new Date('2026-03-11T10:00:00Z')
@@ -134,8 +140,58 @@ describe('IVT Service (Invalid Traffic Detection)', () => {
           });
         }
 
-        const isLimited = await isRateLimited(prisma, '10.0.0.1', 999, new Date('2026-03-12T10:00:00Z'));
+        const isLimited = await isRateLimited(prisma, '10.0.0.1', 9999, new Date('2026-03-12T10:00:00Z'));
         expect(isLimited).toBe(false);
+      });
+    });
+
+    describe('isTooFastClick', () => {
+      beforeEach(async () => {
+        // Setup impression
+        await prisma.impression.create({
+          data: {
+            ad_id: ad1.id,
+            publisher_id: publisher.id,
+            imp_id: 'imp_123',
+            created_at: new Date('2026-03-12T10:00:00.000Z')
+          }
+        });
+      });
+
+      it('should flag click as too fast if it occurs within 1 second (e.g., 500ms)', async () => {
+        const click = {
+          imp_id: 'imp_123',
+          created_at: new Date('2026-03-12T10:00:00.500Z')
+        };
+        const isFast = await isTooFastClick(prisma, click);
+        expect(isFast).toBe(true);
+      });
+
+      it('should NOT flag click as too fast if it occurs after 1 second (e.g., 1500ms)', async () => {
+        const click = {
+          imp_id: 'imp_123',
+          created_at: new Date('2026-03-12T10:00:01.500Z')
+        };
+        const isFast = await isTooFastClick(prisma, click);
+        expect(isFast).toBe(false);
+      });
+
+      it('should flag as invalid if impression ID is missing in click', async () => {
+        const click = {
+          imp_id: null,
+          created_at: new Date('2026-03-12T10:00:01.500Z')
+        };
+        const isFast = await isTooFastClick(prisma, click);
+        expect(isFast).toBe(true);
+      });
+
+      it('should flag as invalid if linked impression is not found', async () => {
+        const click = {
+          imp_id: 'non_existent_imp',
+          created_at: new Date('2026-03-12T10:00:01.500Z')
+        };
+        const isFast = await isTooFastClick(prisma, click);
+        expect(isFast).toBe(true);
       });
     });
   });

--- a/src/services/ivt.ts
+++ b/src/services/ivt.ts
@@ -37,6 +37,25 @@ export async function isRateLimited(prisma: PrismaClient, ipAddress: string, cli
 }
 
 /**
+ * Checks if the click occurred too soon after the impression.
+ * Rule: Minimum 1 second (1000ms) required between impression and click.
+ */
+export async function isTooFastClick(prisma: PrismaClient, click: any): Promise<boolean> {
+  if (!click.imp_id) return true; // Invalid if no impression ID is linked
+
+  const impression = await prisma.impression.findUnique({
+    where: { imp_id: click.imp_id }
+  });
+
+  if (!impression) return true; // Invalid if linked impression is not found
+
+  const timeDiff = click.created_at.getTime() - impression.created_at.getTime();
+  
+  // しきい値: 1000ms (1秒)
+  return timeDiff < 1000;
+}
+
+/**
  * Checks if the click is a duplicate of a recent click.
  * Rule: Identical ad_id and ip_address within 10 seconds.
  */


### PR DESCRIPTION
広告が表示されてからクリックされるまでの時間を計測し、短すぎる場合（1秒未満）を不正クリックとして判定する機能を実装したよっ！(๑˃̵ᴗ˂̵)و✨

### 🛠️ 変更内容
- **imp_id の導入**: 配信（/api/serve）ごとにユニークなIDを発行し、インプレッションとクリックを確実に紐付けられるようにしたよ！🗄️
- **配信ロジックの強化**: 広告配信時に imp_id を発行し、クリエイティブ内の各URLに自動で埋め込むようにしたよ！🚀
- **計測APIの更新**: インプレッションとクリックの各エンドポイントで imp_id を受け取り、DBに保存するようにしたよ！📸🖱️
- **不正判定ロジック (IVT)**: 広告表示から1秒未満のクリックをボットや誤タップとみなし、'Too fast click' として排除するロジックを追加したよ！🛡️🕵️‍♀️
- **BillingWorkerへの統合**: 実際の課金処理ループにこの判定を組み込み、不正クリックには課金されないようにしたよ！💰
- **テストの実装**: IVTサービスとBillingWorkerの両方で、この新しいガードマンが正しく機能することをテストで証明したよ！🧪✨

**closes #105**