### PR TITLE
Setup Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## 概要

Dependabotを設定して、依存関係の更新を自動化します。

## 設定内容

| 項目 | 設定値 |
|-----|-------|
| package-ecosystem | npm |
| schedule | weekly（週1回） |
| day | monday（毎週月曜日） |
| time | 10:00 |
| timezone | Asia/Tokyo |
| open-pull-requests-limit | 5（同時PR上限） |

## メリット

- ✅ セキュリティアップデートを自動検知
- ✅ 手動での依存関係チェックが不要に
- ✅ 毎週月曜日にまとめて確認できる
- ✅ PR数を5つに制限（通知爆発防止）

## マージ後の動作

マージ後、Dependabotが自動的に動作し、次の月曜日10:00から更新チェックを開始します。

closes #115