### PR TITLE
Add dismissed_alerts table migration

### DIFF
--- a/prisma/migrations/20260327183000_add_dismissed_alerts/migration.sql
+++ b/prisma/migrations/20260327183000_add_dismissed_alerts/migration.sql
@@ -1,0 +1,11 @@
+-- Create dismissed_alerts table for optimization alerts
+CREATE TABLE "dismissed_alerts" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "advertiser_id" INTEGER NOT NULL,
+    "alert_type" TEXT NOT NULL,
+    "entity_id" TEXT NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create unique index
+CREATE UNIQUE INDEX "dismissed_alerts_advertiser_id_alert_type_entity_id_key" ON "dismissed_alerts"("advertiser_id", "alert_type", "entity_id");


### PR DESCRIPTION
Create dismissed_alerts table for optimization alerts feature.

## Changes
- Add dismissed_alerts table with advertiser_id, alert_type, entity_id
- Add unique index on (advertiser_id, alert_type, entity_id)

## Why
This table is required for the alert dismiss/restore functionality
implemented in the optimization alerts feature (#122).

## Dependencies
This migration should be merged before #129 (image upload feature)
as #129 depends on test utilities that use this table.

Relates to #122