### PR TITLE
feat: check deliverable ads only for NO_ADS_IN_CAMPAIGN alert

### DIFF
--- a/src/services/alerts.test.ts
+++ b/src/services/alerts.test.ts
@@ -56,7 +56,7 @@ describe('Alerts Service', () => {
       expect(alerts.activeAlerts).toHaveLength(0);
     });
 
-    it('should not detect campaign with ads', async () => {
+    it('should not detect campaign with deliverable ads', async () => {
       const advertiser = await prisma.advertiser.create({
         data: { id: 1, name: 'Test Advertiser' }
       });
@@ -94,6 +94,90 @@ describe('Alerts Service', () => {
       const alerts = await generateOptimizationAlerts(advertiser.id);
 
       expect(alerts.activeAlerts).toHaveLength(0);
+    });
+
+    it('should detect campaign with only pending ads (NO_ADS_IN_CAMPAIGN)', async () => {
+      const advertiser = await prisma.advertiser.create({
+        data: { id: 1, name: 'Test Advertiser' }
+      });
+      
+      const campaign = await prisma.campaign.create({
+        data: {
+          id: 1,
+          advertiser_id: advertiser.id,
+          name: 'Campaign with Pending Ads',
+          status: 'ACTIVE',
+          budget: 10000,
+          daily_budget: 1000,
+        }
+      });
+      
+      const adGroup = await prisma.adGroup.create({
+        data: {
+          id: 1,
+          campaign_id: campaign.id,
+          name: 'Test AdGroup',
+        }
+      });
+      
+      // review_status='pending' の広告は配信可能ではない
+      await prisma.ad.create({
+        data: {
+          id: 1,
+          ad_group_id: adGroup.id,
+          title: 'Pending Ad',
+          target_url: 'http://test.com',
+          review_status: 'pending',
+          status: 'ACTIVE',
+        }
+      });
+
+      const alerts = await generateOptimizationAlerts(advertiser.id);
+
+      expect(alerts.activeAlerts).toHaveLength(1);
+      expect(alerts.activeAlerts[0].id).toBe(`${AlertType.NO_ADS_IN_CAMPAIGN}-1`);
+    });
+
+    it('should detect campaign with only paused ads (NO_ADS_IN_CAMPAIGN)', async () => {
+      const advertiser = await prisma.advertiser.create({
+        data: { id: 1, name: 'Test Advertiser' }
+      });
+      
+      const campaign = await prisma.campaign.create({
+        data: {
+          id: 1,
+          advertiser_id: advertiser.id,
+          name: 'Campaign with Paused Ads',
+          status: 'ACTIVE',
+          budget: 10000,
+          daily_budget: 1000,
+        }
+      });
+      
+      const adGroup = await prisma.adGroup.create({
+        data: {
+          id: 1,
+          campaign_id: campaign.id,
+          name: 'Test AdGroup',
+        }
+      });
+      
+      // status='PAUSED' の広告は配信可能ではない
+      await prisma.ad.create({
+        data: {
+          id: 1,
+          ad_group_id: adGroup.id,
+          title: 'Paused Ad',
+          target_url: 'http://test.com',
+          review_status: 'approved',
+          status: 'PAUSED',
+        }
+      });
+
+      const alerts = await generateOptimizationAlerts(advertiser.id);
+
+      expect(alerts.activeAlerts).toHaveLength(1);
+      expect(alerts.activeAlerts[0].id).toBe(`${AlertType.NO_ADS_IN_CAMPAIGN}-1`);
     });
 
     it('should detect parent paused (PARENT_PAUSED)', async () => {

--- a/src/services/alerts.ts
+++ b/src/services/alerts.ts
@@ -34,17 +34,21 @@ export async function generateOptimizationAlerts(advertiserId: number): Promise<
   // 各キャンペーンをチェック
   for (const campaign of campaigns) {
     // 🔴 Critical: 広告未設定のキャンペーン
-    const totalAds = campaign.adGroups.reduce(
-      (sum, ag) => sum + ag.ads.length, 0
+    // 配信可能な広告 = review_status='approved' かつ status='ACTIVE'
+    const deliverableAds = campaign.adGroups.reduce(
+      (sum, ag) => sum + ag.ads.filter(
+        ad => ad.review_status === 'approved' && ad.status === 'ACTIVE'
+      ).length,
+      0
     );
     
-    if (campaign.status === 'ACTIVE' && totalAds === 0) {
+    if (campaign.status === 'ACTIVE' && deliverableAds === 0) {
       const alertId = `${AlertType.NO_ADS_IN_CAMPAIGN}-${campaign.id}`;
       allAlerts.push({
         id: alertId,
         severity: 'critical' as AlertSeverity,
         title: '配信可能な広告がありません',
-        description: `キャンペーン「${campaign.name}」が有効ですが、紐づく広告が未設定です。`,
+        description: `アクティブなキャンペーンですが、配信可能な広告が1つもありません。`,
         action: {
           label: '広告を追加する',
           type: 'link',


### PR DESCRIPTION
## 概要
配信可能な広告（review_status='approved' かつ status='ACTIVE'）のみをカウントするように修正。

## 変更内容
- &#96;NO_ADS_IN_CAMPAIGN&#96; アラートのカウントロジックを修正
- 配信可能な広告 = review_status='approved' AND status='ACTIVE'
- アラート文言を issue #147 の要件に合わせて更新
- pending / PAUSED 広告のみのケースのテストを追加

## 検証項目
- [x] TypeScriptコンパイル通過
- [x] テスト全通過 (79 tests)
- [x] approved + ACTIVE な広告があればアラート非表示
- [x] pending / PAUSED 広告のみの場合はアラート表示

Closes #147